### PR TITLE
[ADD] account_asset_maintenance

### DIFF
--- a/account_asset_maintenance/README.rst
+++ b/account_asset_maintenance/README.rst
@@ -1,0 +1,79 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================================
+Link between assets and equipments
+==================================
+
+This module links assets with equipments, allowing to create automatically
+an equipment from the supplier invoice if an equipment category is assigned
+in the asset category.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to *Accounting > Configuration > Management > Asset Types*.
+#. Select one asset type.
+#. Fill the field "Equipment category" with the equipment category we want to
+   assign to the auto-created equipments.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to *Accounting > Purchases > Vendor Bills*.
+#. Create a new bill.
+#. Create one invoice line.
+#. Select an asset category with an equipment category filled.
+#. Validate the invoice.
+#. A new page called "Equipments" will appear with the auto-created equipments.
+#. An equipment will created per each quantity indicated in the invoice line.
+#. If the quantity is not integer (for example: 3.5), the upper integer number
+   will be used (4 for the example).
+#. If you cancel the bill, the created equipments will be removed.
+
+You can access equipments for the created asset:
+
+#. Go to *Accounting > Adviser > Assets*.
+#. Open the created asset
+#. You will see an smart-button with the string "Equipments" that links to the
+   created asset.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/92/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-financial-tools/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_asset_maintenance/__init__.py
+++ b/account_asset_maintenance/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/account_asset_maintenance/__manifest__.py
+++ b/account_asset_maintenance/__manifest__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Link between assets and equipments",
+    "summary": "Create equipment when validating an invoice with assets",
+    "version": "10.0.1.0.0",
+    "category": "Accounting & Finance",
+    "website": "https://www.tecnativa.com/",
+    "author": "Tecnativa, "
+              "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": [
+        "account_asset",
+        "account_cancel",
+        "maintenance",
+    ],
+    "data": [
+        "views/account_asset_asset_views.xml",
+        "views/account_asset_category_views.xml",
+        "views/account_invoice_views.xml",
+        "views/maintenance_equipment_views.xml",
+    ],
+}

--- a/account_asset_maintenance/i18n/es.po
+++ b/account_asset_maintenance/i18n/es.po
@@ -1,0 +1,87 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_asset_maintenance
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-07 12:00+0000\n"
+"PO-Revision-Date: 2017-04-07 12:00+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_asset_maintenance
+#: model:ir.model,name:account_asset_maintenance.model_account_asset_category
+msgid "Asset category"
+msgstr "Categoría de activo"
+
+#. module: account_asset_maintenance
+#: code:addons/account_asset_maintenance/models/account_invoice.py:61
+#, python-format
+msgid "Asset category '{}' hasn't got an equipment category assigned."
+msgstr "La categoría de activo '{}'  no tiene una categoría de equipo asignada."
+
+#. module: account_asset_maintenance
+#: model:ir.model,name:account_asset_maintenance.model_account_asset_asset
+msgid "Asset/Revenue Recognition"
+msgstr "Aceptación de pagos/Ingresos"
+
+#. module: account_asset_maintenance
+#: model:ir.model.fields,field_description:account_asset_maintenance.field_maintenance_equipment_asset_ids
+msgid "Assets"
+msgstr "Assets"
+
+#. module: account_asset_maintenance
+#: model:ir.model,name:account_asset_maintenance.model_maintenance_equipment
+msgid "Equipment"
+msgstr "Equipamiento"
+
+#. module: account_asset_maintenance
+#: model:ir.model.fields,field_description:account_asset_maintenance.field_account_asset_category_equipment_category_id
+msgid "Equipment category"
+msgstr "Equipment category"
+
+#. module: account_asset_maintenance
+#: model:ir.model.fields,field_description:account_asset_maintenance.field_account_asset_asset_equipment_count
+msgid "Equipment count"
+msgstr "Equipment count"
+
+#. module: account_asset_maintenance
+#: model:ir.model.fields,field_description:account_asset_maintenance.field_account_asset_asset_equipment_ids
+#: model:ir.model.fields,field_description:account_asset_maintenance.field_account_invoice_equipment_ids
+#: model:ir.model.fields,field_description:account_asset_maintenance.field_account_invoice_line_equipment_ids
+#: model:ir.ui.view,arch_db:account_asset_maintenance.invoice_supplier_form
+#: model:ir.ui.view,arch_db:account_asset_maintenance.view_account_asset_asset_form
+msgid "Equipments"
+msgstr "Equipos"
+
+#. module: account_asset_maintenance
+#: model:ir.model,name:account_asset_maintenance.model_account_invoice
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: account_asset_maintenance
+#: model:ir.model,name:account_asset_maintenance.model_account_invoice_line
+msgid "Invoice Line"
+msgstr "Linea de Factura"
+
+#. module: account_asset_maintenance
+#: model:ir.ui.view,arch_db:account_asset_maintenance.view_account_asset_category_form
+msgid "Maintenance equipments"
+msgstr "Maintenance equipments"
+
+#. module: account_asset_maintenance
+#: model:ir.model.fields,field_description:account_asset_maintenance.field_maintenance_equipment_invoice_line_id
+msgid "Origin line invoice"
+msgstr "Origin line invoice"
+
+#. module: account_asset_maintenance
+#: model:ir.model.fields,help:account_asset_maintenance.field_account_asset_category_equipment_category_id
+msgid "This category will be used for the created equipment when it is created automatically on validating a vendor bill that contains this asset category."
+msgstr "This category will be used for the created equipment when it is created automatically on validating a vendor bill that contains this asset category."
+

--- a/account_asset_maintenance/models/__init__.py
+++ b/account_asset_maintenance/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import account_asset_asset
+from . import account_invoice
+from . import account_asset_category
+from . import maintenance_equipment

--- a/account_asset_maintenance/models/account_asset_asset.py
+++ b/account_asset_maintenance/models/account_asset_asset.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class AccountAssetAsset(models.Model):
+    _inherit = 'account.asset.asset'
+
+    equipment_ids = fields.Many2many(
+        comodel_name="maintenance.equipment", string="Equipments",
+    )
+    equipment_count = fields.Integer(
+        string="Equipment count", compute="_compute_equipment_count",
+    )
+
+    @api.depends('equipment_ids')
+    def _compute_equipment_count(self):
+        for asset in self:
+            asset.equipment_count = len(asset.equipment_ids)
+
+    @api.multi
+    def button_open_equipment(self):
+        self.ensure_one()
+        res = self.env.ref('maintenance.hr_equipment_action').read()[0]
+        res['domain'] = [('asset_ids', 'in', self.ids)]
+        res['context'] = {'default_asset_ids': [(6, 0, self.ids)]}
+        return res

--- a/account_asset_maintenance/models/account_asset_category.py
+++ b/account_asset_maintenance/models/account_asset_category.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountAssetCategory(models.Model):
+    _inherit = 'account.asset.category'
+
+    equipment_category_id = fields.Many2one(
+        comodel_name="maintenance.equipment.category",
+        string="Equipment category",
+        help="This category will be used for the created equipment when it "
+             "is created automatically on validating a vendor bill that "
+             "contains this asset category.",
+    )

--- a/account_asset_maintenance/models/account_invoice.py
+++ b/account_asset_maintenance/models/account_invoice.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+import math
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    equipment_ids = fields.Many2many(
+        comodel_name="maintenance.equipment", compute="_compute_equipment_ids",
+        string="Equipments",
+    )
+
+    @api.multi
+    @api.depends('invoice_line_ids', 'invoice_line_ids.equipment_ids')
+    def _compute_equipment_ids(self):
+        for invoice in self:
+            invoice.equipment_ids = [
+                (6, 0, invoice.mapped('invoice_line_ids.equipment_ids').ids),
+            ]
+
+    @api.multi
+    def action_invoice_cancel(self):
+        res = super(AccountInvoice, self).action_invoice_cancel()
+        self.mapped('equipment_ids').unlink()
+        return res
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = 'account.invoice.line'
+
+    equipment_ids = fields.One2many(
+        comodel_name="maintenance.equipment", inverse_name="invoice_line_id",
+        string="Equipments",
+    )
+
+    def _prepare_equipment_vals_list(self, invoice_line):
+        vals_list = []
+        num = int(math.ceil(invoice_line.quantity))
+        for i in range(num):
+            vals_list.append({
+                'name': "{} [{}/{}]".format(invoice_line.name, i + 1, num),
+                'category_id': (
+                    invoice_line.asset_category_id.equipment_category_id.id
+                ),
+                'invoice_line_id': invoice_line.id,
+                'cost': invoice_line.price_subtotal / invoice_line.quantity,
+                'partner_id': invoice_line.invoice_id.partner_id.id,
+            })
+        return vals_list
+
+    @api.multi
+    def asset_create(self):
+        for line in self.filtered('asset_category_id.equipment_category_id'):
+            # Create equipments
+            equipments = self.env['maintenance.equipment']
+            for vals in self._prepare_equipment_vals_list(line):
+                equipments += equipments.create(vals)
+            # Link assets to equipments
+            # HACK: There's no way to inherit method knowing the created asset
+            prev_assets = self.env['account.asset.asset'].search([])
+            super(AccountInvoiceLine, line).asset_create()
+            current_assets = self.env['account.asset.asset'].search([])
+            asset = current_assets - prev_assets
+            asset.write({'equipment_ids': [(4, x) for x in equipments.ids]})

--- a/account_asset_maintenance/models/maintenance_equipment.py
+++ b/account_asset_maintenance/models/maintenance_equipment.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class MaintenanceEquipment(models.Model):
+    _inherit = 'maintenance.equipment'
+
+    invoice_line_id = fields.Many2one(
+        comodel_name='account.invoice.line', string="Origin line invoice",
+    )
+    asset_ids = fields.Many2many(
+        comodel_name="account.asset.asset", string="Assets",
+    )

--- a/account_asset_maintenance/tests/__init__.py
+++ b/account_asset_maintenance/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_account_asset_maintenance

--- a/account_asset_maintenance/tests/test_account_asset_maintenance.py
+++ b/account_asset_maintenance/tests/test_account_asset_maintenance.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestAccountAssetMaintenance(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestAccountAssetMaintenance, cls).setUpClass()
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'Test partner',
+        })
+        cls.journal = cls.env['account.journal'].create({
+            'name': 'Test journal',
+            'code': 'TEST',
+            'type': 'general',
+            'update_posted': True,
+        })
+        cls.account_type = cls.env['account.account.type'].create({
+            'name': 'Test account type',
+            'type': 'other',
+        })
+        cls.account = cls.env['account.account'].create({
+            'name': 'Test account',
+            'code': 'TEST',
+            'user_type_id': cls.account_type.id,
+        })
+        cls.equipment_category = cls.env[
+            'maintenance.equipment.category'
+        ].create({
+            'name': 'Test equipment category',
+        })
+        cls.asset_category = cls.env['account.asset.category'].create({
+            'name': 'Test assset category',
+            'journal_id': cls.journal.id,
+            'account_asset_id': cls.account.id,
+            'account_depreciation_expense_id': cls.account.id,
+            'account_depreciation_id': cls.account.id,
+            'equipment_category_id': cls.equipment_category.id,
+        })
+        cls.invoice = cls.env['account.invoice'].create({
+            'partner_id': cls.partner.id,
+            'journal_id': cls.journal.id,
+            'type': 'in_invoice',
+            'invoice_line_ids': [
+                (0, 0, {
+                    'name': 'Test line',
+                    'asset_category_id': cls.asset_category.id,
+                    'quantity': 1,
+                    'price_unit': 50,
+                    'account_id': cls.account.id,
+                })
+            ]
+        })
+        cls.invoice_line = cls.invoice.invoice_line_ids[0]
+
+    def test_flow(self):
+        # HACK: There's no way to the created asset
+        prev_assets = self.env['account.asset.asset'].search([])
+        self.invoice.action_invoice_open()
+        current_assets = self.env['account.asset.asset'].search([])
+        asset = current_assets - prev_assets
+        self.assertEqual(len(asset.equipment_ids), 1)
+        res = asset.button_open_equipment()
+        self.assertEqual(res['domain'], [('asset_ids', 'in', asset.ids)])
+        self.assertEqual(len(self.invoice_line.equipment_ids), 1)
+        self.assertEqual(len(self.invoice.equipment_ids), 1)
+        equipment = self.invoice_line.equipment_ids
+        self.assertEqual(equipment.name, 'Test line [1/1]')
+        self.assertEqual(equipment.cost, 50)
+        self.assertEqual(equipment.category_id, self.equipment_category)
+        self.invoice.action_invoice_cancel()
+        self.assertFalse(self.invoice_line.equipment_ids)
+
+    def test_multi(self):
+        self.invoice_line.quantity = 3
+        self.invoice.action_invoice_open()
+        self.assertEqual(len(self.invoice_line.equipment_ids), 3)
+        equipments = self.invoice_line.equipment_ids
+        for i in range(1, 4):
+            self.assertTrue(equipments.filtered(
+                lambda x: x.name == 'Test line [{}/3]'.format(i)
+            ))

--- a/account_asset_maintenance/views/account_asset_asset_views.xml
+++ b/account_asset_maintenance/views/account_asset_asset_views.xml
@@ -1,0 +1,15 @@
+<odoo>
+
+    <record id="view_account_asset_asset_form" model="ir.ui.view">
+        <field name="model">account.asset.asset</field>
+        <field name="inherit_id" ref="account_asset.view_account_asset_asset_form"/>
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button class="oe_stat_button" name="button_open_equipment" type="object" icon="fa-laptop">
+                    <field string="Equipments" name="equipment_count" widget="statinfo"/>
+                </button>
+            </div>
+        </field>
+    </record>
+
+</odoo>

--- a/account_asset_maintenance/views/account_asset_category_views.xml
+++ b/account_asset_maintenance/views/account_asset_category_views.xml
@@ -1,0 +1,15 @@
+<odoo>
+
+    <record id="view_account_asset_category_form" model="ir.ui.view">
+        <field name="model">account.asset.category</field>
+        <field name="inherit_id" ref="account_asset.view_account_asset_category_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="/form/group" position="inside">
+                <group string="Maintenance equipments" name="group_maintenance_equipment">
+                    <field name="equipment_category_id"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/account_asset_maintenance/views/account_invoice_views.xml
+++ b/account_asset_maintenance/views/account_invoice_views.xml
@@ -1,0 +1,21 @@
+<odoo>
+
+    <record id="invoice_supplier_form" model="ir.ui.view">
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_supplier_form"/>
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page string="Equipments"
+                      name="page_equipment"
+                      attrs="{'invisible': [('equipment_ids', '=', [])]}"
+                >
+                    <field name="equipment_ids"
+                           readonly="False"
+                           context="{'tree_view_ref': 'account_asset_maintenance.hr_equipment_view_tree'}"
+                    />
+                </page>
+            </notebook>
+        </field>
+    </record>
+
+</odoo>

--- a/account_asset_maintenance/views/maintenance_equipment_views.xml
+++ b/account_asset_maintenance/views/maintenance_equipment_views.xml
@@ -1,0 +1,26 @@
+<odoo>
+
+    <record id="hr_equipment_view_tree" model="ir.ui.view">
+        <field name="model">maintenance.equipment</field>
+        <field name="inherit_id" ref="maintenance.hr_equipment_view_tree"/>
+        <field name="mode">primary</field>
+        <field name="priority">99999</field>
+        <field name="arch" type="xml">
+            <tree position="attributes">
+                <attribute name="create">0</attribute>
+                <attribute name="delete">0</attribute>
+            </tree>
+        </field>
+    </record>
+
+    <record id="hr_equipment_view_form" model="ir.ui.view">
+        <field name="model">maintenance.equipment</field>
+        <field name="inherit_id" ref="maintenance.hr_equipment_view_form"/>
+        <field name="arch" type="xml">
+            <form position="inside">
+                <field name="asset_ids" invisible="1"/>
+            </form>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Link between assets and equipments
==================================

This module links assets with equipments, allowing to create automatically
an equipment from the supplier invoice if an equipment category is assigned
in the asset category.

Configuration
=============

To configure this module, you need to:

* Go to *Accounting > Configuration > Management > Asset Types*.
* Select one asset type.
* Fill the field "Equipment category" with the equipment category we want to
  assign to the auto-created equipments.

Usage
=====

To use this module, you need to:

* Go to *Accounting > Purchases > Vendor Bills*.
* Create a new bill.
* Create one invoice line.
* Select an asset category with an equipment category filled.
* Validate the invoice.
* A new page called "Equipments" will appear with the auto-created equipments.
* An equipment will created per each quantity indicated in the invoice line.
* If the quantity is not integer (for example: 3.5), the upper integer number
  will be used (4 for the example).
* If you cancel the bill, the created equipments will be removed.

You can access equipments for the created asset:

* Go to *Accounting > Adviser > Assets*.
* Open the created asset
* You will see an smart-button with the string "Equipments" that links to the
  created asset.