### PR TITLE
[ADD] maintenance_plan module

### DIFF
--- a/maintenance_plan/README.rst
+++ b/maintenance_plan/README.rst
@@ -14,6 +14,19 @@ Installation
 
 Install the module.
 
+Should you already use the maintenance module and have equipments with field
+'Preventive Maintenance Frequency' defined, a new maintenance plan will be
+automatically created on these equipments with maintenance kind 'Install'.
+
+Moreover if a Request of type 'preventive' exists, whose stage isn't marked as
+'Request done', and has a Request Date matching the equipment's
+'Next Preventive Maintenance', the request will be updated with the
+'Install' maintenance kind.
+
+Make sure you don't have multiple 'preventive' requests at a stage which isn't
+marked as 'Request done' and on the same 'Request date' as the equipment or
+the module installation will fail with a User Error.
+
 
 Usage
 =====

--- a/maintenance_plan/README.rst
+++ b/maintenance_plan/README.rst
@@ -1,0 +1,81 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+================
+Maintenance Plan
+================
+
+This module extends the functionality of Odoo Maintenance module by allowing
+an equipment to have different preventive maintenance kinds.
+
+Installation
+============
+
+Install the module.
+
+
+Usage
+=====
+
+Instead of defining a period and duration for only one preventive maintenance
+per equipment, you can define multiple preventive maintenance kind for each
+equipment.
+
+Maintenance Kinds have to be defined through the configuration menu. Their name
+have to be unique and can be set as active or inactive, should these not be
+used anymore.
+
+On any equipment over the maintenance tab, the maintenance plan will appear
+as an embedded list view, allowing to add different maintenance kind with their
+own period and duration. The next maintenance date will then be computed
+automatically according to today's date and the period defined, but the
+maintenance request won't be created automatically as is the case in Odoo's
+Maintenance module.
+
+Instead, this module uses the original Cron job of Odoo's Maintenance module
+to generate maintenance requests, should there not be any requests which is not
+done, at the request date matching the maintenance plan next_maintenance_date
+for this equipment and this maintenance kind !
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/{repo_id}/10.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/maintenance/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Akim Juillerat <akim.juillerat@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/maintenance_plan/__init__.py
+++ b/maintenance_plan/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import post_init_hook

--- a/maintenance_plan/__init__.py
+++ b/maintenance_plan/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/maintenance_plan/__manifest__.py
+++ b/maintenance_plan/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{'name': 'Maintenance Plan',
+ 'version': '10.0.1.0.0',
+ 'author': 'Odoo Community Association (OCA), Camptocamp SA',
+ 'license': 'AGPL-3',
+ 'category': 'Maintenance',
+ 'website': 'http://www.camptocamp.com',
+ 'images': [],
+ 'depends': [
+     'maintenance',
+     ],
+ 'data': [
+     'security/ir.model.access.csv',
+     'views/maintenance.xml'
+     ],
+ 'demo': [
+     'data/demo_maintenance_plan.xml'
+ ],
+ 'installable': True,
+ 'auto_install': False,
+ }

--- a/maintenance_plan/__manifest__.py
+++ b/maintenance_plan/__manifest__.py
@@ -2,6 +2,7 @@
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Maintenance Plan',
+ 'summary': 'Extends preventive maintenance planning',
  'version': '10.0.1.0.0',
  'author': 'Odoo Community Association (OCA), Camptocamp SA',
  'license': 'AGPL-3',

--- a/maintenance_plan/__manifest__.py
+++ b/maintenance_plan/__manifest__.py
@@ -18,6 +18,7 @@
  'demo': [
      'data/demo_maintenance_plan.xml'
  ],
+ 'post_init_hook': 'post_init_hook',
  'installable': True,
  'auto_install': False,
  }

--- a/maintenance_plan/data/demo_maintenance_plan.xml
+++ b/maintenance_plan/data/demo_maintenance_plan.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!--  Maintenance kinds -->
+        <record id="maintenance_kind_monthly" model="maintenance.kind">
+            <field name="name">Monthly</field>
+            <field name="active" eval="True" />
+        </record>
+        <record id="maintenance_kind_weekly" model="maintenance.kind">
+            <field name="name">Weekly</field>
+            <field name="active" eval="True" />
+        </record>
+
+        <!--  Maintenance plans -->
+        <record id="maintenance_plan_monthly_monitor1" model="maintenance.plan">
+            <field name="equipment_id" ref="maintenance.equipment_monitor1" />
+            <field name="maintenance_kind_id" ref="maintenance_kind_monthly" />
+            <field name="period">30</field>
+            <field name="duration">2</field>
+        </record>
+
+        <record id="maintenance_plan_monthly_monitor4" model="maintenance.plan">
+            <field name="equipment_id" ref="maintenance.equipment_monitor4" />
+            <field name="maintenance_kind_id" ref="maintenance_kind_monthly" />
+            <field name="period">30</field>
+            <field name="duration">2</field>
+        </record>
+
+        <record id="maintenance_plan_monthly_monitor6" model="maintenance.plan">
+            <field name="equipment_id" ref="maintenance.equipment_monitor6" />
+            <field name="maintenance_kind_id" ref="maintenance_kind_monthly" />
+            <field name="period">30</field>
+            <field name="duration">2</field>
+        </record>
+
+        <record id="maintenance_plan_monthly_printer1" model="maintenance.plan">
+            <field name="equipment_id" ref="maintenance.equipment_printer1" />
+            <field name="maintenance_kind_id" ref="maintenance_kind_monthly" />
+            <field name="period">30</field>
+            <field name="duration">4</field>
+        </record>
+
+        <record id="maintenance_plan_weekly_printer1" model="maintenance.plan">
+            <field name="equipment_id" ref="maintenance.equipment_printer1" />
+            <field name="maintenance_kind_id" ref="maintenance_kind_weekly" />
+            <field name="period">7</field>
+            <field name="duration">1</field>
+        </record>
+
+    </data>
+</odoo>

--- a/maintenance_plan/hooks.py
+++ b/maintenance_plan/hooks.py
@@ -30,10 +30,11 @@ def post_init_hook(cr, registry):
                 r.request_date == equipment.next_action_date)
             if len(request) > 1:
                 raise UserError(_(
-                    "You have multiple preventive maintenance requests on an "
-                    "equipment's next action date. Please leave only one "
-                    "request as preventive on the date of equipment's next "
-                    "action to install the module."))
+                    "You have multiple preventive maintenance requests on "
+                    "equipment %s next action date (%s). Please leave only "
+                    "one preventive request on the date of equipment's next "
+                    "action to install the module."
+                ) % (equipment.name, equipment.next_action_date))
             elif len(request) == 1:
                 request.write({
                     'maintenance_kind_id': maintenance_kind.id,

--- a/maintenance_plan/hooks.py
+++ b/maintenance_plan/hooks.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+from odoo import SUPERUSER_ID, api, _
+from odoo.exceptions import UserError
+
+
+def post_init_hook(cr, registry):
+
+    logging.getLogger('odoo.addons.maintenance_plan').info(
+        'Migrating existing preventive maintenance')
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    equipments = env['maintenance.equipment'].search([('period', '!=', False)])
+
+    if equipments:
+
+        maintenance_kind = env['maintenance.kind'].create({
+            'name': 'Install',
+            'active': True,
+        })
+
+        for equipment in equipments:
+            request = equipment.maintenance_ids.filtered(
+                lambda r: r.maintenance_type == 'preventive' and not
+                r.stage_id.done and
+                r.request_date == equipment.next_action_date)
+            if len(request) > 1:
+                raise UserError(_(
+                    "You have multiple preventive maintenance requests on an "
+                    "equipment's next action date. Please leave only one "
+                    "request as preventive on the date of equipment's next "
+                    "action to install the module."))
+            elif len(request) == 1:
+                request.write({
+                    'maintenance_kind_id': maintenance_kind.id,
+                })
+            env['maintenance.plan'].create({
+                'equipment_id': equipment.id,
+                'maintenance_kind_id': maintenance_kind.id,
+                'duration': equipment.maintenance_duration,
+                'period': equipment.period
+            })

--- a/maintenance_plan/models/__init__.py
+++ b/maintenance_plan/models/__init__.py
@@ -1,0 +1,1 @@
+from . import maintenance

--- a/maintenance_plan/models/maintenance.py
+++ b/maintenance_plan/models/maintenance.py
@@ -111,7 +111,8 @@ class MaintenancePlan(models.Model):
 
     _sql_constraints = [
         ('equipment_kind_uniq', 'unique (equipment_id, maintenance_kind_id)',
-         "This kind of maintenance already exists for this equipment !")]
+         "You cannot define multiple times the same maintenance kind on an "
+         "equipment maintenance plan!")]
 
 
 class MaintenanceEquipment(models.Model):

--- a/maintenance_plan/models/maintenance.py
+++ b/maintenance_plan/models/maintenance.py
@@ -29,7 +29,8 @@ class MaintenancePlan(models.Model):
                                    comodel_name='maintenance.equipment',
                                    ondelete='cascade')
     maintenance_kind_id = fields.Many2one(string='Maintenance kind',
-                                          comodel_name='maintenance.kind')
+                                          comodel_name='maintenance.kind',
+                                          ondelete='restrict')
 
     period = fields.Integer(string='Period',
                             help='Days between each maintenance')
@@ -214,4 +215,5 @@ class MaintenanceRequest(models.Model):
     _inherit = 'maintenance.request'
 
     maintenance_kind_id = fields.Many2one(string='Maintenance kind',
-                                          comodel_name='maintenance.kind')
+                                          comodel_name='maintenance.kind',
+                                          ondelete='restrict')

--- a/maintenance_plan/models/maintenance.py
+++ b/maintenance_plan/models/maintenance.py
@@ -25,7 +25,8 @@ class MaintenancePlan(models.Model):
     _description = 'Maintenance Plan'
 
     equipment_id = fields.Many2one(string='Equipment',
-                                   comodel_name='maintenance.equipment')
+                                   comodel_name='maintenance.equipment',
+                                   ondelete='cascade')
     maintenance_kind_id = fields.Many2one(string='Maintenance kind',
                                           comodel_name='maintenance.kind')
 

--- a/maintenance_plan/models/maintenance.py
+++ b/maintenance_plan/models/maintenance.py
@@ -121,6 +121,14 @@ class MaintenanceEquipment(models.Model):
     maintenance_plan_ids = fields.One2many(string='Maintenance plan',
                                            comodel_name='maintenance.plan',
                                            inverse_name='equipment_id')
+    maintenance_team_required = fields.Boolean(
+        compute='_compute_team_required')
+
+    @api.depends('maintenance_plan_ids')
+    def _compute_team_required(self):
+        for equipment in self:
+            equipment.maintenance_team_required = len(
+                equipment.maintenance_plan_ids) >= 1
 
     def _create_new_request(self, maintenance_plan):
         self.ensure_one()

--- a/maintenance_plan/models/maintenance.py
+++ b/maintenance_plan/models/maintenance.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, api, _
+from datetime import timedelta
+
+
+class MaintenanceKind(models.Model):
+
+    _name = 'maintenance.kind'
+    _description = 'Maintenance Kind'
+
+    name = fields.Char('Name', required=True, translate=True)
+    active = fields.Boolean('Active Kind', required=True, default=True)
+
+    _sql_constraints = [
+        ('name_uniq', 'unique (name)',
+         "Maintenance kind name already exists !")]
+
+
+class MaintenancePlan(models.Model):
+
+    _name = 'maintenance.plan'
+    _description = 'Maintenance Plan'
+
+    equipment_id = fields.Many2one(string='Equipment',
+                                   comodel_name='maintenance.equipment')
+    maintenance_kind_id = fields.Many2one(string='Maintenance kind',
+                                          comodel_name='maintenance.kind')
+
+    period = fields.Integer(string='Period',
+                            help='Days between each maintenance')
+    duration = fields.Float(string='Duration',
+                            help='Maintenance duration in hours')
+
+    next_maintenance_date = fields.Date('Next maintenance date',
+                                        compute='_compute_next_maintenance')
+
+    @api.depends('period', 'maintenance_kind_id',
+                 'equipment_id.maintenance_ids.request_date',
+                 'equipment_id.maintenance_ids.close_date',
+                 'equipment_id.maintenance_ids.maintenance_kind_id')
+    def _compute_next_maintenance(self):
+
+        date_now = fields.Date.context_today(self)
+        today_date = fields.Date.from_string(date_now)
+
+        for plan in self.filtered(lambda x: x.period > 0):
+
+            period_timedelta = timedelta(days=plan.period)
+
+            next_maintenance_todo = self.env['maintenance.request'].search([
+                ('equipment_id', '=', plan.equipment_id.id),
+                ('maintenance_type', '=', 'preventive'),
+                ('maintenance_kind_id', '=', plan.maintenance_kind_id.id),
+                ('stage_id.done', '!=', True),
+                ('close_date', '=', False)], order="request_date asc", limit=1)
+            last_maintenance_done = self.env['maintenance.request'].search([
+                ('equipment_id', '=', plan.equipment_id.id),
+                ('maintenance_type', '=', 'preventive'),
+                ('maintenance_kind_id', '=', plan.maintenance_kind_id.id),
+                ('stage_id.done', '=', True),
+                ('close_date', '!=', False)], order="close_date desc", limit=1)
+            if next_maintenance_todo and last_maintenance_done:
+                next_date = next_maintenance_todo.request_date
+                date_gap = fields.Date.from_string(
+                    next_maintenance_todo.request_date) - \
+                    fields.Date.from_string(last_maintenance_done.close_date)
+                # If the gap between the last_maintenance_done and the
+                # next_maintenance_todo one is bigger than 2 times the period
+                # and next request is in the future
+                # We use 2 times the period to avoid creation too closed
+                # request from a manually one created
+                if date_gap > max(timedelta(0), period_timedelta * 2) \
+                        and fields.Date.from_string(
+                            next_maintenance_todo.request_date) > today_date:
+                    # If the new date still in the past, we set it for today
+                    if fields.Date.from_string(
+                            last_maintenance_done.close_date) + \
+                            period_timedelta < today_date:
+                        next_date = date_now
+                    else:
+                        next_date = fields.Date.to_string(
+                            fields.Date.from_string(
+                                last_maintenance_done.close_date) +
+                            period_timedelta)
+            elif next_maintenance_todo:
+                next_date = next_maintenance_todo.request_date
+                date_gap = fields.Date.from_string(
+                    next_maintenance_todo.request_date) - today_date
+                # If next maintenance to do is in the future, and in more than
+                # 2 times the period, we insert an new request
+                # We use 2 times the period to avoid creation too closed
+                # request from a manually one created
+                if date_gap > timedelta(0) and date_gap > period_timedelta * 2:
+                    next_date = fields.Date.to_string(
+                        today_date + period_timedelta)
+            elif last_maintenance_done:
+                next_date = fields.Date.from_string(
+                    last_maintenance_done.close_date) + period_timedelta
+                # If when we add the period to the last maintenance done and
+                # we still in past, we plan it for today
+                if next_date < today_date:
+                    next_date = date_now
+            else:
+                next_date = fields.Date.to_string(
+                    today_date + period_timedelta)
+
+            plan.next_maintenance_date = next_date
+
+    _sql_constraints = [
+        ('equipment_kind_uniq', 'unique (equipment_id, maintenance_kind_id)',
+         "This kind of maintenance already exists for this equipment !")]
+
+
+class MaintenanceEquipment(models.Model):
+
+    _inherit = 'maintenance.equipment'
+
+    maintenance_plan_ids = fields.One2many(string='Maintenance plan',
+                                           comodel_name='maintenance.plan',
+                                           inverse_name='equipment_id')
+
+    def _create_new_request(self, maintenance_plan):
+        self.ensure_one()
+        self.env['maintenance.request'].create({
+            'name': _('Preventive Maintenance (%s) - %s') %
+            (maintenance_plan.maintenance_kind_id.name,
+             self.name),
+            'request_date': maintenance_plan.next_maintenance_date,
+            'schedule_date': maintenance_plan.next_maintenance_date,
+            'category_id': self.category_id.id,
+            'equipment_id': self.id,
+            'maintenance_type': 'preventive',
+            'owner_user_id': self.owner_user_id.id or self.env.user.id,
+            'technician_user_id': self.technician_user_id.id,
+            'maintenance_team_id': self.maintenance_team_id.id,
+            'maintenance_kind_id': maintenance_plan.maintenance_kind_id.id,
+            'duration': maintenance_plan.duration,
+        })
+
+    @api.model
+    def _cron_generate_requests(self):
+        """
+            Generates maintenance request on the next_maintenance_date or
+            today if none exists
+        """
+        for plan in self.env['maintenance.plan'].search([('period', '>', 0)]):
+            equipment = plan.equipment_id
+            next_requests = self.env['maintenance.request'].search(
+                [('stage_id.done', '=', False),
+                 ('equipment_id', '=', equipment.id),
+                 ('maintenance_type', '=', 'preventive'),
+                 ('maintenance_kind_id', '=', plan.maintenance_kind_id.id),
+                 ('request_date', '=', plan.next_maintenance_date)])
+            if not next_requests:
+                equipment._create_new_request(plan)
+
+    @api.depends('maintenance_plan_ids.next_maintenance_date',
+                 'maintenance_ids.request_date')
+    def _compute_next_maintenance(self):
+        """ Redefine the function to display next_action_date in kanban view"""
+        for equipment in self:
+            next_plan_dates = equipment.maintenance_plan_ids.mapped(
+                'next_maintenance_date')
+            next_unplanned_dates = self.env['maintenance.request'].search([
+                ('equipment_id', '=', equipment.id),
+                ('maintenance_kind_id', '=', None),
+                ('request_date', '>', fields.Date.context_today(self)),
+                ('stage_id.done', '!=', True),
+                ('close_date', '=', False)
+            ]).mapped('request_date')
+            if len(next_plan_dates + next_unplanned_dates) <= 0:
+                equipment.next_action_date = None
+            else:
+                equipment.next_action_date = min(next_plan_dates +
+                                                 next_unplanned_dates)
+
+
+class MaintenanceRequest(models.Model):
+
+    _inherit = 'maintenance.request'
+
+    maintenance_kind_id = fields.Many2one(string='Maintenance kind',
+                                          comodel_name='maintenance.kind')

--- a/maintenance_plan/models/maintenance.py
+++ b/maintenance_plan/models/maintenance.py
@@ -17,7 +17,7 @@ class MaintenanceKind(models.Model):
 
     _sql_constraints = [
         ('name_uniq', 'unique (name)',
-         "Maintenance kind name already exists !")]
+         "Maintenance kind name already exists.")]
 
 
 class MaintenancePlan(models.Model):
@@ -135,7 +135,7 @@ class MaintenancePlan(models.Model):
     _sql_constraints = [
         ('equipment_kind_uniq', 'unique (equipment_id, maintenance_kind_id)',
          "You cannot define multiple times the same maintenance kind on an "
-         "equipment maintenance plan!")]
+         "equipment maintenance plan.")]
 
 
 class MaintenanceEquipment(models.Model):

--- a/maintenance_plan/models/maintenance.py
+++ b/maintenance_plan/models/maintenance.py
@@ -154,12 +154,10 @@ class MaintenanceEquipment(models.Model):
             equipment.maintenance_team_required = len(
                 equipment.maintenance_plan_ids) >= 1
 
-    def _create_new_request(self, maintenance_plan):
-        self.ensure_one()
-        self.env['maintenance.request'].create({
-            'name': _('Preventive Maintenance (%s) - %s') %
-            (maintenance_plan.maintenance_kind_id.name,
-             self.name),
+    def _prepare_request_from_plan(self, maintenance_plan):
+        return {
+            'name': _('Preventive Maintenance (%s) - %s') % (
+                maintenance_plan.maintenance_kind_id.name, self.name),
             'request_date': maintenance_plan.next_maintenance_date,
             'schedule_date': maintenance_plan.next_maintenance_date,
             'category_id': self.category_id.id,
@@ -170,7 +168,12 @@ class MaintenanceEquipment(models.Model):
             'maintenance_team_id': self.maintenance_team_id.id,
             'maintenance_kind_id': maintenance_plan.maintenance_kind_id.id,
             'duration': maintenance_plan.duration,
-        })
+        }
+
+    def _create_new_request(self, maintenance_plan):
+        self.ensure_one()
+        vals = self._prepare_request_from_plan(maintenance_plan)
+        self.env['maintenance.request'].create(vals)
 
     @api.model
     def _cron_generate_requests(self):

--- a/maintenance_plan/security/ir.model.access.csv
+++ b/maintenance_plan/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_maintenance_kind_user,access_maintenance_kind_user,model_maintenance_kind,base.group_user,1,0,0,0
+access_maintenance_plan_user,access_maintenance_plan_user,model_maintenance_plan,base.group_user,1,0,0,0
+access_maintenance_kind_manager,access_maintenance_kind_manager,model_maintenance_kind,maintenance.group_equipment_manager,1,1,1,1
+access_maintenance_plan_manager,access_maintenance_plan_manager,model_maintenance_plan,maintenance.group_equipment_manager,1,1,1,1

--- a/maintenance_plan/tests/test_maintenance_plan.py
+++ b/maintenance_plan/tests/test_maintenance_plan.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import odoo.tests.common as test_common
+from odoo import fields
+from datetime import timedelta
+
+
+class TestMaintenancePlan(test_common.TransactionCase):
+
+    def setUp(self):
+        super(TestMaintenancePlan, self).setUp()
+        self.printer1 = self.env.ref('maintenance.equipment_printer1')
+        self.cron = self.env.ref('maintenance.maintenance_requests_cron')
+
+    def test_next_maintenance_date(self):
+
+        today = fields.Date.today()
+        today_date = fields.Date.from_string(today)
+
+        for plan in self.printer1.maintenance_plan_ids:
+            self.assertEqual(plan.next_maintenance_date,
+                             fields.Date.to_string(
+                                 today_date + timedelta(days=plan.period)))
+
+    def test_generate_requests(self):
+
+        self.cron.method_direct_trigger()
+
+        generated_requests = self.env['maintenance.request'].search(
+            ['|',
+             ('maintenance_kind_id', '=', self.env.ref(
+                 'maintenance_plan.maintenance_kind_monthly').id),
+             ('maintenance_kind_id', '=', self.env.ref(
+                 'maintenance_plan.maintenance_kind_weekly').id)
+             ])
+
+        for req in generated_requests:
+            for plan in req.equipment_id.maintenance_plan_ids:
+                if plan.maintenance_kind_id == req.maintenance_kind_id:
+                    self.assertEqual(req.duration, plan.duration)
+                    self.assertEqual(req.request_date,
+                                     plan.next_maintenance_date)

--- a/maintenance_plan/views/maintenance.xml
+++ b/maintenance_plan/views/maintenance.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <!-- maintenance.kind : views -->
-    <record id="maintenance_kind_view_search" model="ir.ui.view">
-        <field name="name">maintenance.kind.search</field>
-        <field name="model">maintenance.kind</field>
-        <field name="arch" type="xml">
-            <search string="Maintenance Kinds">
-               <field name="name" string="Maintenance Kinds"/>
-            </search>
-        </field>
-    </record>
-
     <record id="maintenance_kind_view_tree" model="ir.ui.view">
         <field name="name">maintenance.kind.tree</field>
         <field name="model">maintenance.kind</field>

--- a/maintenance_plan/views/maintenance.xml
+++ b/maintenance_plan/views/maintenance.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- maintenance.kind : views -->
+    <record id="maintenance_kind_view_search" model="ir.ui.view">
+        <field name="name">maintenance.kind.search</field>
+        <field name="model">maintenance.kind</field>
+        <field name="arch" type="xml">
+            <search string="Maintenance Kinds">
+               <field name="name" string="Maintenance Kinds"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="maintenance_kind_view_tree" model="ir.ui.view">
+        <field name="name">maintenance.kind.tree</field>
+        <field name="model">maintenance.kind</field>
+        <field name="arch" type="xml">
+            <tree string="Maintenance Kinds" editable="true">
+                <field name="name"/>
+                <field name="active"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- maintenance.kind : actions -->
+    <record id="maintenance_kind_action" model="ir.actions.act_window">
+        <field name="name">Kinds</field>
+        <field name="res_model">maintenance.kind</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="maintenance_kind_view_tree"/>
+    </record>
+
+    <menuitem
+        id="menu_maintenance_kind_configuration"
+        name="Maintenance Kinds"
+        parent="maintenance.menu_maintenance_configuration"
+        action="maintenance_kind_action"
+        sequence="4" />
+
+
+    <!-- maintenance.plan : views -->
+    <record id="maintenance_plan_view_form" model="ir.ui.view">
+        <field name="name">maintenance.plan.form</field>
+        <field name="model">maintenance.plan</field>
+        <field name="arch" type="xml">
+            <form string="Maintenance Plan">
+                <group>
+                    <field name="maintenance_kind_id"/>
+                    <field name="period"/>
+                    <field name="duration"/>
+                    <field name="next_maintenance_date"/>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="maintenance_plan_view_tree" model="ir.ui.view">
+        <field name="name">maintenance.plan.tree</field>
+        <field name="model">maintenance.plan</field>
+        <field name="arch" type="xml">
+            <tree string="Maintenance Plans">
+                <field name="maintenance_kind_id"/>
+                <field name="period"/>
+                <field name="duration"/>
+                <field name="next_maintenance_date"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- equipment : views inheritance -->
+    <record id="hr_equipment_view_form" model="ir.ui.view">
+        <field name="name">equipment.form.inherit</field>
+        <field name="inherit_id" ref="maintenance.hr_equipment_view_form" />
+        <field name="model">maintenance.equipment</field>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='maintenance']" position="replace">
+                <group name="maintenance">
+                    <field name="maintenance_plan_ids" />
+                    <field name="next_action_date" invisible="1"/>
+                    <field name="period" invisible="1"/>
+                    <field name="maintenance_duration" invisible="1"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/maintenance_plan/views/maintenance.xml
+++ b/maintenance_plan/views/maintenance.xml
@@ -76,11 +76,12 @@
             <xpath expr="//group[@name='maintenance']" position="replace">
                 <group name="maintenance">
                     <field name="maintenance_plan_ids" />
-                    <field name="next_action_date" invisible="1"/>
-                    <field name="period" invisible="1"/>
-                    <field name="maintenance_duration" invisible="1"/>
+                    <field name="maintenance_team_required" invisible="1"/>
                 </group>
             </xpath>
+            <field name="maintenance_team_id" position="attributes">
+                <attribute name="attrs">{'required': [('maintenance_team_required', '=', True)]}</attribute>
+            </field>
         </field>
     </record>
 

--- a/maintenance_plan/views/maintenance.xml
+++ b/maintenance_plan/views/maintenance.xml
@@ -83,4 +83,16 @@
             </xpath>
         </field>
     </record>
+
+    <!-- request : views inheritance -->
+    <record id="hr_equipment_request_view_form" model="ir.ui.view">
+        <field name="name">equipment.request.form.inherit</field>
+        <field name="model">maintenance.request</field>
+        <field name="inherit_id" ref="maintenance.hr_equipment_request_view_form" />
+        <field name="arch" type="xml">
+            <field name="maintenance_type" position="after">
+                <field name="maintenance_kind_id" />
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/maintenance_plan/views/maintenance.xml
+++ b/maintenance_plan/views/maintenance.xml
@@ -24,7 +24,7 @@
 
     <!-- maintenance.kind : actions -->
     <record id="maintenance_kind_action" model="ir.actions.act_window">
-        <field name="name">Kinds</field>
+        <field name="name">Maintenance kinds</field>
         <field name="res_model">maintenance.kind</field>
         <field name="view_mode">tree</field>
         <field name="view_id" ref="maintenance_kind_view_tree"/>
@@ -32,7 +32,7 @@
 
     <menuitem
         id="menu_maintenance_kind_configuration"
-        name="Maintenance Kinds"
+        name="Maintenance kinds"
         parent="maintenance.menu_maintenance_configuration"
         action="maintenance_kind_action"
         sequence="4" />


### PR DESCRIPTION
================
Maintenance Plan
================

This module extends the functionality of Odoo Maintenance module by allowing
an equipment to have different preventive maintenance kinds.

Installation
============

Install the module.


Usage
=====

Instead of defining a period and duration for only one preventive maintenance
per equipment, you can define multiple preventive maintenance kind for each
equipment.

Maintenance Kinds have to be defined through the configuration menu. Their name
have to be unique and can be set as active or inactive, should these not be
used anymore.

On any equipment over the maintenance tab, the maintenance plan will appear
as an embedded list view, allowing to add different maintenance kind with their
own period and duration. The next maintenance date will then be computed
automatically according to today's date and the period defined, but the
maintenance request won't be created automatically as is the case in Odoo's
Maintenance module.

Instead, this module uses the original Cron job of Odoo's Maintenance module
to generate maintenance requests, should there not be any requests which is not
done, at the request date matching the maintenance plan next_maintenance_date
for this equipment and this maintenance kind !
