### PR TITLE
[FIX] maintenance_equipment_scrap: fixes in README

### DIFF
--- a/maintenance_equipment_scrap/README.rst
+++ b/maintenance_equipment_scrap/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
    :alt: License: AGPL-3
 
 ============================
@@ -34,13 +34,13 @@ Moreover, if on the equipment an 'Equipment Scrap Template Email' was set, such 
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/92/10.0
+   :target: https://runbot.odoo-community.org/runbot/240/10.0
 
 Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues
-<https://github.com/OCA/account-financial-tools/issues>`_. In case of trouble, please
+<https://github.com/OCA/maintenance/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
 help us smash it by providing detailed and welcomed feedback.
 
@@ -52,6 +52,8 @@ Contributors
 
 * Antonio Esposito <a.esposito@onestein.nl>
 * Andrea Stirpe <a.stirpe@onestein.nl>
+
+Do not contact contributors directly about support or help with technical issues.
 
 Maintainer
 ----------


### PR DESCRIPTION
This PR fixes the following issues in the README of _maintenance_equipment_scrap_:

- wrong repo id in "Try me on Runbot"
- wrong repo name in "GitHub Issues" link
- update image .svg->.png, according with latest template
- update agpl link, according with latest template
- add "Do not contact contributors directly ..."