### PR TITLE
[FIX] maintenance_project: tabs instead of spaces in equipment view form

### DIFF
--- a/maintenance_project/views/maintenance_equipment_views.xml
+++ b/maintenance_project/views/maintenance_equipment_views.xml
@@ -46,7 +46,7 @@
             </xpath>
             <xpath expr="//group[@name='maintenance']" position="after">
                 <group name="project_task">
-		            <field name="preventive_default_task_id"
+                    <field name="preventive_default_task_id"
                            domain="[('project_id', '=', project_id)]"
                            context="{'default_project_id': project_id}"/>
                 </group>


### PR DESCRIPTION
This travis flake test was previously passed; anyway I fix it, because other PRs that use `maintenance_project` will fail without this correction