### PR TITLE
[12.0] [FIX] maintenance_plan: cron generated request should inherit equipment company

### DIFF
--- a/maintenance_plan/models/maintenance.py
+++ b/maintenance_plan/models/maintenance.py
@@ -150,6 +150,7 @@ class MaintenanceEquipment(models.Model):
         return {
             'name': _('Preventive Maintenance (%s) - %s') % (
                 maintenance_plan.maintenance_kind_id.name, self.name),
+            'company_id': self.company_id.id,
             'request_date': maintenance_plan.next_maintenance_date,
             'schedule_date': maintenance_plan.next_maintenance_date,
             'category_id': self.category_id.id,


### PR DESCRIPTION
When a request is generated from a plan within the cron, no company is filled, so the request is created with OdooBot company instead of equipment request one.
This PR passes equipment company to the request.