### PR TITLE
[12.0] [FIX] maintenance_plan: next_maintenance_date should be stored

### DIFF
--- a/maintenance_plan/models/maintenance.py
+++ b/maintenance_plan/models/maintenance.py
@@ -37,7 +37,8 @@ class MaintenancePlan(models.Model):
     duration = fields.Float(help='Maintenance duration in hours')
 
     next_maintenance_date = fields.Date('Next maintenance date',
-                                        compute='_compute_next_maintenance')
+                                        compute='_compute_next_maintenance',
+                                        store=True)
 
     @api.depends('period', 'maintenance_kind_id',
                  'equipment_id.maintenance_ids.request_date',


### PR DESCRIPTION
The current definition of `next_maintenance_date` is incomplete: it has a computed method with `api.depends` decorator, but is not stored. This PR fixes it. 
This change will increase the speed of processes such as cron maintenance request generation.