### PR TITLE
[12.0] [IMP] maintenance_plan: make next_maintenance_date field editable

### DIFF
--- a/maintenance_plan/models/maintenance.py
+++ b/maintenance_plan/models/maintenance.py
@@ -38,7 +38,8 @@ class MaintenancePlan(models.Model):
 
     next_maintenance_date = fields.Date('Next maintenance date',
                                         compute='_compute_next_maintenance',
-                                        store=True)
+                                        store=True,
+                                        readonly=False)
 
     @api.depends('period', 'maintenance_kind_id',
                  'equipment_id.maintenance_ids.request_date',


### PR DESCRIPTION
This PR allows to edit `next_maintenance_date` computed and stored field of the `maintenance_plan` module