### PR TITLE
[12.0][FIX] maintenance_timesheet: python literal text not translatable

### DIFF
--- a/maintenance_timesheet/i18n/maintenance_timesheet.pot
+++ b/maintenance_timesheet/i18n/maintenance_timesheet.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-11-12 11:34+0000\n"
+"PO-Revision-Date: 2019-11-12 11:34+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -26,6 +28,12 @@ msgstr ""
 #. module: maintenance_timesheet
 #: model:ir.model,name:maintenance_timesheet.model_account_analytic_line
 msgid "Analytic Line"
+msgstr ""
+
+#. module: maintenance_timesheet
+#: code:addons/maintenance_timesheet/models/hr_timesheet.py:46
+#, python-format
+msgid "Cannot save or delete a timesheet for a maintenance request already done"
 msgstr ""
 
 #. module: maintenance_timesheet

--- a/maintenance_timesheet/models/hr_timesheet.py
+++ b/maintenance_timesheet/models/hr_timesheet.py
@@ -4,9 +4,6 @@
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
 
-BAD_TIMESHEET_REQUEST_DONE_MSG = \
-    'Cannot save or delete a timesheet for a maintenance request already done'
-
 
 class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
@@ -46,4 +43,5 @@ class AccountAnalyticLine(models.Model):
         Editing a timesheet related to a finished request is forbidden.
         """
         if self.env['maintenance.request'].browse(request_id).stage_id.done:
-            raise ValidationError(_(BAD_TIMESHEET_REQUEST_DONE_MSG))
+            raise ValidationError(_('Cannot save or delete a timesheet for '
+                                    'a maintenance request already done'))

--- a/maintenance_timesheet/tests/test_maintenance_timesheet.py
+++ b/maintenance_timesheet/tests/test_maintenance_timesheet.py
@@ -4,7 +4,6 @@
 import odoo.tests.common as test_common
 from odoo import fields
 from odoo.exceptions import ValidationError
-from ..models import hr_timesheet
 
 
 class TestMaintenanceTimesheet(test_common.TransactionCase):
@@ -48,26 +47,20 @@ class TestMaintenanceTimesheet(test_common.TransactionCase):
 
     def test_check_request_done(self):
         self.request2.stage_id = self.stage_done
-        with self.assertRaises(ValidationError) as context:
+        with self.assertRaises(ValidationError):
             self.request2.timesheet_ids = [(0, 0, {
                 'name': 'Attempt to create a task for a done request',
                 'project_id': self.request2.project_id.id,
                 'user_id': self.env.ref('base.user_admin').id,
                 'date': fields.Date.today(),
                 'unit_amount': 2})]
-        self.assertTrue(hr_timesheet.BAD_TIMESHEET_REQUEST_DONE_MSG
-                        in str(context.exception))
-        with self.assertRaises(ValidationError) as context:
+        with self.assertRaises(ValidationError):
             # Attempt to modify a timesheet related a done request
             for timesheet in self.request2.timesheet_ids:
                 timesheet.unit_amount += 1
-        self.assertTrue(hr_timesheet.BAD_TIMESHEET_REQUEST_DONE_MSG
-                        in str(context.exception))
-        with self.assertRaises(ValidationError) as context:
+        with self.assertRaises(ValidationError):
             # Attempt to delete a timesheet related a done request
             self.request2.timesheet_ids.unlink()
-        self.assertTrue(hr_timesheet.BAD_TIMESHEET_REQUEST_DONE_MSG
-                        in str(context.exception))
 
     def test_action_view_timesheet_ids(self):
         act1 = self.request2.action_view_timesheet_ids()


### PR DESCRIPTION
A text defined as variable was wrongly defined in order to be translatable. With this PR the issue is solved