### PR TITLE
[11.0][FIX] default equipment_id in plans

### DIFF
--- a/maintenance_plan/views/maintenance_equipment_views.xml
+++ b/maintenance_plan/views/maintenance_equipment_views.xml
@@ -17,7 +17,7 @@
             </div>
             <xpath expr="//group[@name='maintenance']/.." position="replace">
                 <group name="maintenance">
-                    <field name="maintenance_plan_ids" nolabel="1">
+                    <field name="maintenance_plan_ids" nolabel="1" context="{'default_equipment_id': active_id, 'hide_equipment_id': 1}">
                         <tree string="Plans">
                             <field name="maintenance_kind_id"/>
                             <field name="name"/>

--- a/maintenance_plan/views/maintenance_plan_views.xml
+++ b/maintenance_plan/views/maintenance_plan_views.xml
@@ -34,7 +34,7 @@
                         <h1><field name="name" placeholder="e.g. Calibration"/></h1>
                     </div>
                     <group>
-                        <field name="equipment_id"/>
+                        <field name="equipment_id" invisible="context.get('hide_equipment_id', 0)"/>
                         <field name="maintenance_kind_id"/>
                     </group>
                     <group>


### PR DESCRIPTION
When creating a plan from equipment's form you had to select the equipment_id again. With this change the field is automatically set and hidden when accessing from the equipment's form.

@etobella @LoisRForgeFlow @JordiBForgeFlow @AdriaGForgeFlow 