### PR TITLE
[11.0][IMP] maintenance_plan: Add team on plans

### DIFF
--- a/maintenance_plan/models/maintenance_equipment.py
+++ b/maintenance_plan/models/maintenance_equipment.py
@@ -29,11 +29,13 @@ class MaintenanceEquipment(models.Model):
     def _compute_team_required(self):
         for equipment in self:
             equipment.maintenance_team_required = len(
-                equipment.maintenance_plan_ids) >= 1
+                equipment.maintenance_plan_ids.filtered(
+                    lambda r: not r.maintenance_team_id
+                )) >= 1
 
     def _prepare_request_from_plan(self, maintenance_plan,
                                    next_maintenance_date):
-        team = self.maintenance_team_id
+        team = maintenance_plan.maintenance_team_id or self.maintenance_team_id
         if not team:
             team = self.env['maintenance.request']._get_default_team_id()
         return {

--- a/maintenance_plan/models/maintenance_plan.py
+++ b/maintenance_plan/models/maintenance_plan.py
@@ -77,6 +77,7 @@ class MaintenancePlan(models.Model):
         string="Current Maintenance",
         store=True,
     )
+    maintenance_team_id = fields.Many2one('maintenance.team')
 
     @api.depends('maintenance_ids.stage_id.done')
     def _compute_maintenance_count(self):

--- a/maintenance_plan/views/maintenance_equipment_views.xml
+++ b/maintenance_plan/views/maintenance_equipment_views.xml
@@ -20,6 +20,7 @@
                     <field name="maintenance_plan_ids" nolabel="1" context="{'default_equipment_id': active_id, 'hide_equipment_id': 1}">
                         <tree string="Plans">
                             <field name="maintenance_kind_id"/>
+                            <field name="maintenance_team_id"/>
                             <field name="name"/>
                             <field name="start_maintenance_date"/>
                             <field name="interval"/>

--- a/maintenance_plan/views/maintenance_plan_views.xml
+++ b/maintenance_plan/views/maintenance_plan_views.xml
@@ -36,6 +36,7 @@
                     <group>
                         <field name="equipment_id" invisible="context.get('hide_equipment_id', 0)"/>
                         <field name="maintenance_kind_id"/>
+                        <field name="maintenance_team_id"/>
                     </group>
                     <group>
                         <group>
@@ -73,6 +74,7 @@
             <tree string="Maintenance Plans" decoration-muted="active == False">
                 <field name="equipment_id"/>
                 <field name="maintenance_kind_id"/>
+                <field name="maintenance_team_id"/>
                 <field name="name"/>
                 <field name="start_maintenance_date"/>
                 <field name="interval"/>
@@ -93,6 +95,7 @@
             <search string="Maintenance Plans">
                 <field name="equipment_id"/>
                 <field name="maintenance_kind_id"/>
+                <field name="maintenance_team_id"/>
                 <field name="name"/>
                 <field name="start_maintenance_date"/>
                 <filter string="Active" name="active" domain="[('active', '=',True)]"/>


### PR DESCRIPTION
With this module, we can change the default team of a plan. For example, we could have a team for callibration and another one for technical reviews.
@jarroyomorales @dalonsod @LoisRForgeFlow 