### PR TITLE
[12.0][FIX] maintenance_plan: prevent False as display name when name is empty

### DIFF
--- a/maintenance_plan/i18n/maintenance_plan.pot
+++ b/maintenance_plan/i18n/maintenance_plan.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-01-02 16:00+0000\n"
+"PO-Revision-Date: 2020-01-02 16:00+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -312,7 +314,7 @@ msgid "Start maintenance date"
 msgstr ""
 
 #. module: maintenance_plan
-#: code:addons/maintenance_plan/models/maintenance_plan.py:130
+#: code:addons/maintenance_plan/models/maintenance_plan.py:139
 #, python-format
 msgid "The maintenance plan %s of equipment %s has generated a request which is not done yet. You should either set the request as done, remove its maintenance kind or delete it first."
 msgstr ""
@@ -320,6 +322,14 @@ msgstr ""
 #. module: maintenance_plan
 #: model_terms:ir.ui.view,arch_db:maintenance_plan.maintenance_plan_view_search
 msgid "Under Maintenance"
+msgstr ""
+
+#. module: maintenance_plan
+#: code:addons/maintenance_plan/models/maintenance_plan.py:88
+#: code:addons/maintenance_plan/tests/test_maintenance_plan.py:44
+#: code:addons/maintenance_plan/tests/test_maintenance_plan.py:49
+#, python-format
+msgid "Unnamed %s plan (%s)"
 msgstr ""
 
 #. module: maintenance_plan

--- a/maintenance_plan/models/maintenance_plan.py
+++ b/maintenance_plan/models/maintenance_plan.py
@@ -80,6 +80,15 @@ class MaintenancePlan(models.Model):
     )
     maintenance_team_id = fields.Many2one('maintenance.team')
 
+    def name_get(self):
+        result = []
+        for plan in self:
+            result.append((
+                plan.id,
+                plan.name or _('Unnamed %s plan (%s)') %
+                (plan.maintenance_kind_id.name or '', plan.equipment_id.name)))
+        return result
+
     @api.depends('maintenance_ids.stage_id.done')
     def _compute_maintenance_count(self):
         for equipment in self:

--- a/maintenance_plan/tests/test_maintenance_plan.py
+++ b/maintenance_plan/tests/test_maintenance_plan.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import odoo.tests.common as test_common
-from odoo import fields
+from odoo import fields, _
 from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 
@@ -26,9 +26,40 @@ class TestMaintenancePlan(test_common.TransactionCase):
             'maintenance_plan_horizon': 2,
             'planning_step': 'month'
         })
+        self.maintenance_plan_2 = self.maintenance_plan_obj.create({
+            'equipment_id': self.equipment_1.id,
+            'maintenance_kind_id': self.env.ref(
+                'maintenance_plan.maintenance_kind_weekly').id,
+            'interval': 1,
+            'interval_step': 'week',
+            'maintenance_plan_horizon': 2,
+            'planning_step': 'month'
+        })
+        self.maintenance_plan_3 = self.maintenance_plan_obj.create({
+            'name': 'My custom plan',
+            'equipment_id': self.equipment_1.id,
+            'interval': 2,
+            'interval_step': 'week',
+            'maintenance_plan_horizon': 2,
+            'planning_step': 'month'
+        })
 
         today = fields.Date.today()
         self.today_date = fields.Date.from_string(today)
+
+    def test_name_get(self):
+        self.assertEqual(
+            self.maintenance_plan_1.name_get()[0][1],
+            _('Unnamed %s plan (%s)') % (
+                '', self.maintenance_plan_1.equipment_id.name))
+        self.assertEqual(
+            self.maintenance_plan_2.name_get()[0][1],
+            _('Unnamed %s plan (%s)') % (
+                self.maintenance_plan_2.maintenance_kind_id.name,
+                self.maintenance_plan_2.equipment_id.name))
+        self.assertEqual(
+            self.maintenance_plan_3.name_get()[0][1],
+            self.maintenance_plan_3.name)
 
     def test_next_maintenance_date(self):
         # We set start maintenance date tomorrow and check next maintenance


### PR DESCRIPTION
Since `name` field for `maintenance.plan` is not required, this PR implements a `name_get()` method to prevent `False` to be displayed in the form navigation widget.

E.g. if an "Equipment A" has a "Monthly" kind plan _and name is empty_, "Unnamed Montly plan (Equipment A)" is finally shown.

cc @etobella 