### PR TITLE
[11.0][IMP] maintenance_plan: no equipment

### DIFF
--- a/maintenance_plan/models/maintenance_equipment.py
+++ b/maintenance_plan/models/maintenance_equipment.py
@@ -38,9 +38,15 @@ class MaintenanceEquipment(models.Model):
         team = maintenance_plan.maintenance_team_id or self.maintenance_team_id
         if not team:
             team = self.env['maintenance.request']._get_default_team_id()
+
+        description = self.name if self else maintenance_plan.name
+        kind = maintenance_plan.maintenance_kind_id.name or _(
+            'Unspecified kind'
+        )
+        name = _('Preventive Maintenance (%s) - %s') % (kind, description)
+
         return {
-            'name': _('Preventive Maintenance (%s) - %s') % (
-                maintenance_plan.maintenance_kind_id.name, self.name),
+            'name': name,
             'request_date': next_maintenance_date,
             'schedule_date': next_maintenance_date,
             'category_id': self.category_id.id,
@@ -56,7 +62,6 @@ class MaintenanceEquipment(models.Model):
         }
 
     def _create_new_request(self, maintenance_plan):
-        self.ensure_one()
         # Compute horizon date adding to today the planning horizon
         horizon_date = fields.Date.from_string(
             fields.Date.today()) + get_relativedelta(
@@ -79,8 +84,9 @@ class MaintenanceEquipment(models.Model):
         while next_maintenance_date <= horizon_date:
             if next_maintenance_date >= fields.Date.from_string(
                     fields.Date.today()):
-                vals = self._prepare_request_from_plan(maintenance_plan,
-                                                       next_maintenance_date)
+                vals = self._prepare_request_from_plan(
+                    maintenance_plan, next_maintenance_date
+                )
                 requests |= self.env['maintenance.request'].create(vals)
             next_maintenance_date = next_maintenance_date + get_relativedelta(
                 maintenance_plan.interval, maintenance_plan.interval_step)

--- a/maintenance_plan/views/maintenance_plan_views.xml
+++ b/maintenance_plan/views/maintenance_plan_views.xml
@@ -31,12 +31,12 @@
                     </div>
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only"/>
-                        <h1><field name="name" placeholder="e.g. Calibration"/></h1>
+                        <h1><field name="name" placeholder="e.g. Calibration" attrs="{'required': [('equipment_id', '=', False)]}"/></h1>
                     </div>
                     <group>
                         <field name="equipment_id" invisible="context.get('hide_equipment_id', 0)"/>
                         <field name="maintenance_kind_id"/>
-                        <field name="maintenance_team_id"/>
+                        <field name="maintenance_team_id" attrs="{'required': [('equipment_id', '=', False)]}"/>
                     </group>
                     <group>
                         <group>


### PR DESCRIPTION
If no equipment was set for a plan, the cron used to fail because of an expected singleton. This PR solves this, allowing you to define plans without equipment.

@etobella @LoisRForgeFlow @NuriaMForgeFlow 