### PR TITLE
[12.0][FIX] maintenance_project_plan: hides maintenance_plan original context

### DIFF
--- a/maintenance_project_plan/views/maintenance_equipment_views.xml
+++ b/maintenance_project_plan/views/maintenance_equipment_views.xml
@@ -6,7 +6,10 @@
         <field name="model">maintenance.equipment</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='maintenance_plan_ids']" position="attributes">
-                <attribute name="context">{'default_project_id': project_id, 'default_task_id': preventive_default_task_id}</attribute>
+                <attribute name="context">{
+                    'default_equipment_id': active_id, 'hide_equipment_id': 1,
+                    'default_project_id': project_id,
+                    'default_task_id': preventive_default_task_id}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Before `maintenance_plan `major changes, when creating a plan from an equipment `maintenance_project_plan` this addon is overwriting context generation and not respecting the current one defined in maintenance_plan. So, the current behavior is incorrect: the equipment is shown in the plan form view and not filled with the active one.