### PR TITLE
[12.0][FIX] maintenance_timesheet: use button placeholder in request form

### DIFF
--- a/maintenance_timesheet/views/maintenance_request_views.xml
+++ b/maintenance_timesheet/views/maintenance_request_views.xml
@@ -52,22 +52,16 @@
         </field>
     </record>
 
-    <record id="hr_equipment_request_view_form" model="ir.ui.view">
+    <record id="equipment_request_view_form" model="ir.ui.view">
         <field name="model">maintenance.request</field>
-        <field name="inherit_id" ref="maintenance.hr_equipment_request_view_form" />
-        <field name="priority" eval="110"/>
+        <field name="inherit_id" ref="base_maintenance.equipment_request_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('oe_right')]" position="replace">
-                <div class="oe_button_box" name="button_box">
-                    <button class="oe_stat_button" type="object" name="action_view_timesheet_ids" icon="fa-calendar"
-                            groups="hr_timesheet.group_hr_timesheet_user">
-                        <field name="timesheet_total_hours"  widget="timesheet_uom" />
-                        <span class="o_label" style="padding-left: 5px;">Hours</span>
-                    </button>
-                </div>
-            </xpath>
-            <xpath expr="//div[hasclass('oe_title')]" position="before">
-              <field name="kanban_state" class="oe_inline" widget="state_selection"/>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button class="oe_stat_button" type="object" name="action_view_timesheet_ids" icon="fa-calendar"
+                        groups="hr_timesheet.group_hr_timesheet_user">
+                    <field name="timesheet_total_hours"  widget="timesheet_uom" />
+                    <span class="o_label" style="padding-left: 5px;">Hours</span>
+                </button>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This PR fixes that v12 addon implementation duplicates button box in maintenance request form view (already existing in `base_maintenance` addon). This change is already present in v13, so no cherry pick is needed.