### PR TITLE
[13.0][FIX] maintenance_equipment_status: status not clickable on equipment form

### DIFF
--- a/maintenance_equipment_status/views/maintenance_equipment_views.xml
+++ b/maintenance_equipment_status/views/maintenance_equipment_views.xml
@@ -10,7 +10,7 @@
                 <field
                     name="status_id"
                     widget="statusbar"
-                    clickable="True"
+                    options="{'clickable': '1'}"
                     domain="['|', ('category_ids', 'in', [category_id]), ('category_ids', '=', False)]"
                 />
             </xpath>


### PR DESCRIPTION
Fixes #103 

cc @etobella @alexandreduf 