### PR TITLE
[12.0][FIX] maintenance_plan: migration script wrong syntax

### DIFF
--- a/maintenance_plan/migrations/12.0.2.3.0/post-migration.py
+++ b/maintenance_plan/migrations/12.0.2.3.0/post-migration.py
@@ -12,7 +12,7 @@ def fill_interval_column(cr):
                 maintenance_plan mp2
             INNER JOIN
                 maintenance_equipment meq ON mp2.equipment_id = meq.id
-            WHERE period is not null and mp2.id = mp.id
+            WHERE meq.period is not null and mp2.id = mp.id
         """
     )
 


### PR DESCRIPTION
With current syntax an "ambiguous column" error is fired, in `WHERE` clause I think. Also, in `SET` clause the table alias points to the wrong table.

cc @AdriaGForgeFlow @AaronHForgeFlow 