### PR TITLE
[13.0][FIX] base_maintenance: maintenance team view fixes

### DIFF
--- a/base_maintenance/views/maintenance_team_views.xml
+++ b/base_maintenance/views/maintenance_team_views.xml
@@ -33,19 +33,4 @@
             </field>
         </field>
     </record>
-    <!-- There is no search view to inherit, so creating it-->
-    <record id="maintenance_team_view_search" model="ir.ui.view">
-        <field name="name">maintenance.team.search</field>
-        <field name="model">maintenance.team</field>
-        <field name="arch" type="xml">
-            <search>
-                <field name="name" />
-                <filter
-                    string="Archived"
-                    name="inactive"
-                    domain="[('active','=',False)]"
-                />
-            </search>
-        </field>
-    </record>
 </odoo>

--- a/base_maintenance/views/maintenance_team_views.xml
+++ b/base_maintenance/views/maintenance_team_views.xml
@@ -20,6 +20,19 @@
             </xpath>
         </field>
     </record>
+    <record id="maintenance_team_view_tree" model="ir.ui.view">
+        <field name="name">maintenance.team.tree</field>
+        <field name="model">maintenance.team</field>
+        <field name="inherit_id" ref="maintenance.maintenance_team_view_tree" />
+        <field name="arch" type="xml">
+            <field name="member_ids" position="before">
+                <field name="user_id" />
+            </field>
+            <field name="member_ids" position="after">
+                <field name="description" />
+            </field>
+        </field>
+    </record>
     <!-- There is no search view to inherit, so creating it-->
     <record id="maintenance_team_view_search" model="ir.ui.view">
         <field name="name">maintenance.team.search</field>


### PR DESCRIPTION
* search view already in core. Not need to forward port to v14, fixed there during migration.
* show user_id and member_ids in tree view. Since the tree view is editable when accessing in the configuration menu, the new field need to be showed also in the tree view.

@ForgeFlow