### PR TITLE
[14.0][FIX] base_maintenance: show user_id and member_ids in tree view.

### DIFF
--- a/base_maintenance/views/maintenance_team_views.xml
+++ b/base_maintenance/views/maintenance_team_views.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Copyright 2019 ForgeFlow S.L.
+<!-- Copyright 2019-21 ForgeFlow S.L.
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0) -->
 <odoo>
     <record id="maintenance_team_view_form" model="ir.ui.view">
@@ -18,6 +18,19 @@
                     />
                 </group>
             </xpath>
+        </field>
+    </record>
+    <record id="maintenance_team_view_tree" model="ir.ui.view">
+        <field name="name">maintenance.team.tree</field>
+        <field name="model">maintenance.team</field>
+        <field name="inherit_id" ref="maintenance.maintenance_team_view_tree" />
+        <field name="arch" type="xml">
+            <field name="member_ids" position="before">
+                <field name="user_id" />
+            </field>
+            <field name="member_ids" position="after">
+                <field name="description" />
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Since the tree view is editable when accessing in the configuration
menu, the new field need to be showed also in the tree view.

Forward port of https://github.com/OCA/maintenance/pull/153.

@ForgeFlow