### PR TITLE
[12.0][FIX] maintenance_plan: Remake the computation of next date

### DIFF
--- a/maintenance_plan/models/maintenance_plan.py
+++ b/maintenance_plan/models/maintenance_plan.py
@@ -116,16 +116,18 @@ class MaintenancePlan(models.Model):
                     ("maintenance_plan_id", "=", plan.id),
                     ("stage_id.done", "!=", True),
                     ("close_date", "=", False),
+                    ("request_date", ">=", plan.start_maintenance_date)
                 ],
-                order="request_date desc",
+                order="request_date asc",
                 limit=1,
             )
 
             if next_maintenance_todo:
                 plan.next_maintenance_date = next_maintenance_todo.request_date
             else:
-                last_maintenance_done = self.env["maintenance.request"].search(
-                    [("maintenance_plan_id", "=", plan.id)],
+                last_maintenance_done = self.env["maintenance.request"].search([
+                    ("maintenance_plan_id", "=", plan.id),
+                    ("request_date", ">=", plan.start_maintenance_date)],
                     order="request_date desc",
                     limit=1,
                 )

--- a/maintenance_plan/models/maintenance_plan.py
+++ b/maintenance_plan/models/maintenance_plan.py
@@ -98,32 +98,46 @@ class MaintenancePlan(models.Model):
                 len(equipment.maintenance_ids.filtered(
                     lambda x: not x.stage_id.done))
 
-    @api.depends('interval', 'interval_step', 'maintenance_kind_id',
-                 'equipment_id.maintenance_ids.request_date',
-                 'equipment_id.maintenance_ids.close_date',
-                 'equipment_id.maintenance_ids.maintenance_kind_id')
+    @api.depends(
+        "interval",
+        "interval_step",
+        "start_maintenance_date",
+        "maintenance_ids.request_date",
+        "maintenance_ids.close_date",
+    )
     def _compute_next_maintenance(self):
-
         for plan in self.filtered(lambda x: x.interval > 0):
 
-            interval_timedelta = get_relativedelta(
-                plan.interval, plan.interval_step)
+            interval_timedelta = get_relativedelta(plan.interval,
+                                                   plan.interval_step)
 
-            next_maintenance_todo = self.env['maintenance.request'].search([
-                ('equipment_id', '=', plan.equipment_id.id),
-                ('maintenance_type', '=', 'preventive'),
-                ('maintenance_kind_id', '=', plan.maintenance_kind_id.id),
-                ('maintenance_plan_id', '=', plan.id),
-                ('stage_id.done', '!=', True),
-                ('close_date', '=', False)], order="request_date asc", limit=1)
+            next_maintenance_todo = self.env["maintenance.request"].search(
+                [
+                    ("maintenance_plan_id", "=", plan.id),
+                    ("stage_id.done", "!=", True),
+                    ("close_date", "=", False),
+                ],
+                order="request_date desc",
+                limit=1,
+            )
 
             if next_maintenance_todo:
                 plan.next_maintenance_date = next_maintenance_todo.request_date
             else:
-                next_date = plan.start_maintenance_date
-                while next_date < fields.Date.today():
-                    next_date = next_date + interval_timedelta
-                plan.next_maintenance_date = next_date
+                last_maintenance_done = self.env["maintenance.request"].search(
+                    [("maintenance_plan_id", "=", plan.id)],
+                    order="request_date desc",
+                    limit=1,
+                )
+                if last_maintenance_done:
+                    plan.next_maintenance_date = (
+                        last_maintenance_done.request_date + interval_timedelta
+                    )
+                else:
+                    next_date = plan.start_maintenance_date
+                    while next_date < fields.Date.today():
+                        next_date = next_date + interval_timedelta
+                    plan.next_maintenance_date = next_date
 
     @api.multi
     def unlink(self):

--- a/maintenance_plan/tests/test_maintenance_plan.py
+++ b/maintenance_plan/tests/test_maintenance_plan.py
@@ -11,6 +11,12 @@ class TestMaintenancePlan(test_common.TransactionCase):
 
     def setUp(self):
         super().setUp()
+        self.env = self.env(
+            context=dict(
+                self.env.context,
+                tracking_disable=True,
+            )
+        )
         self.maintenance_request_obj = self.env['maintenance.request']
         self.maintenance_plan_obj = self.env['maintenance.plan']
         self.maintenance_equipment_obj = self.env['maintenance.equipment']
@@ -18,12 +24,16 @@ class TestMaintenancePlan(test_common.TransactionCase):
         self.weekly_kind = self.env.ref(
             'maintenance_plan.maintenance_kind_weekly'
         )
+        self.done_stage = self.env.ref("maintenance.stage_3")
 
         self.equipment_1 = self.maintenance_equipment_obj.create({
             'name': 'Laptop 1',
         })
+        today = fields.Date.today()
+        self.today_date = fields.Date.from_string(today)
         self.maintenance_plan_1 = self.maintenance_plan_obj.create({
             'equipment_id': self.equipment_1.id,
+            'start_maintenance_date': today,
             'interval': 1,
             'interval_step': 'month',
             'maintenance_plan_horizon': 2,
@@ -54,9 +64,6 @@ class TestMaintenancePlan(test_common.TransactionCase):
             'planning_step': 'month'
         })
 
-        today = fields.Date.today()
-        self.today_date = fields.Date.from_string(today)
-
     def test_name_get(self):
         self.assertEqual(
             self.maintenance_plan_1.name_get()[0][1],
@@ -71,7 +78,7 @@ class TestMaintenancePlan(test_common.TransactionCase):
             self.maintenance_plan_3.name_get()[0][1],
             self.maintenance_plan_3.name)
 
-    def test_next_maintenance_date(self):
+    def test_next_maintenance_date_01(self):
         # We set start maintenance date tomorrow and check next maintenance
         # date has been correctly computed
         self.maintenance_plan_1.write({
@@ -86,6 +93,76 @@ class TestMaintenancePlan(test_common.TransactionCase):
             fields.Date.from_string(
                 self.maintenance_plan_1.start_maintenance_date) +
             relativedelta(months=self.maintenance_plan_1.interval)
+        )
+
+    def test_next_maintenance_date_02(self):
+        self.cron.method_direct_trigger()
+        generated_requests = self.maintenance_request_obj.search(
+            [('maintenance_plan_id', '=', self.maintenance_plan_1.id)],
+            order="schedule_date asc"
+        )
+        self.assertEqual(len(generated_requests), 3)
+        next_maintenance = generated_requests[0]
+        next_date = fields.Date.from_string(next_maintenance.request_date)
+        # First maintenance was planned today:
+        self.assertEqual(next_date, self.today_date)
+        self.assertEqual(
+            next_date,
+            fields.Date.from_string(self.maintenance_plan_1.start_maintenance_date),
+        )
+        self.assertEqual(next_date, fields.Date.from_string(
+            self.maintenance_plan_1.next_maintenance_date))
+        # Complete request:
+        next_maintenance.stage_id = self.done_stage
+        # Check next one:
+        next_maintenance = generated_requests[1]
+        next_date = fields.Date.from_string(next_maintenance.request_date)
+        # This should be expected next month:
+        self.assertEqual(
+            next_date,
+            self.today_date + relativedelta(months=self.maintenance_plan_1.interval),
+        )
+        self.assertEqual(next_date, fields.Date.from_string(
+            self.maintenance_plan_1.next_maintenance_date))
+        # Complete request and Check next one:
+        next_maintenance.stage_id = self.done_stage
+        next_maintenance = generated_requests[2]
+        next_date = fields.Date.from_string(next_maintenance.request_date)
+        # This one should be expected in 2 months:
+        self.assertEqual(
+            next_date,
+            self.today_date + relativedelta(
+                months=2 * self.maintenance_plan_1.interval),
+        )
+        self.assertEqual(next_date, fields.Date.from_string(
+            self.maintenance_plan_1.next_maintenance_date))
+        # Move it to a date before `start_maintenance_date` (the request should
+        # be ignored)
+        past_date = self.today_date + relativedelta(
+            months=-3 * self.maintenance_plan_1.interval)
+        next_maintenance.request_date = past_date
+        self.assertNotEqual(past_date, fields.Date.from_string(
+            self.maintenance_plan_1.next_maintenance_date))
+        self.assertEqual(
+            fields.Date.from_string(
+                self.maintenance_plan_1.next_maintenance_date),
+            self.today_date + relativedelta(
+                months=2 * self.maintenance_plan_1.interval),
+        )
+        # Move the request_date far into the future:
+        future_date = self.today_date + relativedelta(
+            months=5 * self.maintenance_plan_1.interval)
+        next_maintenance.request_date = future_date
+        self.assertEqual(future_date, fields.Date.from_string(
+            self.maintenance_plan_1.next_maintenance_date))
+        # Complete request in that date, next expected date should be 1 month
+        # after latest request done.:
+        next_maintenance.stage_id = self.done_stage
+        self.assertEqual(
+            fields.Date.from_string(
+                self.maintenance_plan_1.next_maintenance_date),
+            self.today_date + relativedelta(
+                months=6 * self.maintenance_plan_1.interval),
         )
 
     def test_generate_requests(self):


### PR DESCRIPTION
Commit 1
------------
  
* Use latest request_date both for done and todo searches.
* When there is a latest done apply interval

Backport of https://github.com/OCA/maintenance/pull/162. Related to https://github.com/OCA/maintenance/issues/161.

Commit 2
------------

Forward port of https://github.com/OCA/maintenance/pull/167.

@ForgeFlow