### PR TITLE
[14.0][IMP] maintenance_plan: next maintenance date tweaks

### DIFF
--- a/maintenance_plan/models/maintenance_plan.py
+++ b/maintenance_plan/models/maintenance_plan.py
@@ -127,8 +127,9 @@ class MaintenancePlan(models.Model):
                     ("maintenance_plan_id", "=", plan.id),
                     ("stage_id.done", "!=", True),
                     ("close_date", "=", False),
+                    ("request_date", ">=", plan.start_maintenance_date),
                 ],
-                order="request_date desc",
+                order="request_date asc",
                 limit=1,
             )
 
@@ -136,7 +137,10 @@ class MaintenancePlan(models.Model):
                 plan.next_maintenance_date = next_maintenance_todo.request_date
             else:
                 last_maintenance_done = self.env["maintenance.request"].search(
-                    [("maintenance_plan_id", "=", plan.id)],
+                    [
+                        ("maintenance_plan_id", "=", plan.id),
+                        ("request_date", ">=", plan.start_maintenance_date),
+                    ],
                     order="request_date desc",
                     limit=1,
                 )

--- a/maintenance_plan/tests/test_maintenance_plan.py
+++ b/maintenance_plan/tests/test_maintenance_plan.py
@@ -12,16 +12,26 @@ from odoo import _, fields
 class TestMaintenancePlan(test_common.TransactionCase):
     def setUp(self):
         super().setUp()
+        self.env = self.env(
+            context=dict(
+                self.env.context,
+                tracking_disable=True,
+            )
+        )
         self.maintenance_request_obj = self.env["maintenance.request"]
         self.maintenance_plan_obj = self.env["maintenance.plan"]
         self.maintenance_equipment_obj = self.env["maintenance.equipment"]
         self.cron = self.env.ref("maintenance.maintenance_requests_cron")
         self.weekly_kind = self.env.ref("maintenance_plan.maintenance_kind_weekly")
+        self.done_stage = self.env.ref("maintenance.stage_3")
 
         self.equipment_1 = self.maintenance_equipment_obj.create({"name": "Laptop 1"})
+        today = fields.Date.today()
+        self.today_date = fields.Date.from_string(today)
         self.maintenance_plan_1 = self.maintenance_plan_obj.create(
             {
                 "equipment_id": self.equipment_1.id,
+                "start_maintenance_date": today,
                 "interval": 1,
                 "interval_step": "month",
                 "maintenance_plan_horizon": 2,
@@ -59,9 +69,6 @@ class TestMaintenancePlan(test_common.TransactionCase):
             }
         )
 
-        today = fields.Date.today()
-        self.today_date = fields.Date.from_string(today)
-
     def test_name_get(self):
         self.assertEqual(
             self.maintenance_plan_1.name_get()[0][1],
@@ -79,7 +86,7 @@ class TestMaintenancePlan(test_common.TransactionCase):
             self.maintenance_plan_3.name_get()[0][1], self.maintenance_plan_3.name
         )
 
-    def test_next_maintenance_date(self):
+    def test_next_maintenance_date_01(self):
         # We set start maintenance date tomorrow and check next maintenance
         # date has been correctly computed
         self.maintenance_plan_1.write(
@@ -95,6 +102,86 @@ class TestMaintenancePlan(test_common.TransactionCase):
             fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
             fields.Date.from_string(self.maintenance_plan_1.start_maintenance_date)
             + relativedelta(months=self.maintenance_plan_1.interval),
+        )
+
+    def test_next_maintenance_date_02(self):
+        self.cron.method_direct_trigger()
+        generated_requests = self.maintenance_request_obj.search(
+            [("maintenance_plan_id", "=", self.maintenance_plan_1.id)],
+            order="schedule_date asc",
+        )
+        self.assertEqual(len(generated_requests), 3)
+        next_maintenance = generated_requests[0]
+        next_date = fields.Date.from_string(next_maintenance.request_date)
+        # First maintenance was planned today:
+        self.assertEqual(next_date, self.today_date)
+        self.assertEqual(
+            next_date,
+            fields.Date.from_string(self.maintenance_plan_1.start_maintenance_date),
+        )
+        self.assertEqual(
+            next_date,
+            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+        )
+        # Complete request:
+        next_maintenance.stage_id = self.done_stage
+        # Check next one:
+        next_maintenance = generated_requests[1]
+        next_date = fields.Date.from_string(next_maintenance.request_date)
+        # This should be expected next month:
+        self.assertEqual(
+            next_date,
+            self.today_date + relativedelta(months=self.maintenance_plan_1.interval),
+        )
+        self.assertEqual(
+            next_date,
+            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+        )
+        # Complete request and Check next one:
+        next_maintenance.stage_id = self.done_stage
+        next_maintenance = generated_requests[2]
+        next_date = fields.Date.from_string(next_maintenance.request_date)
+        # This one should be expected in 2 months:
+        self.assertEqual(
+            next_date,
+            self.today_date
+            + relativedelta(months=2 * self.maintenance_plan_1.interval),
+        )
+        self.assertEqual(
+            next_date,
+            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+        )
+        # Move it to a date before `start_maintenance_date` (the request should
+        # be ignored)
+        past_date = self.today_date + relativedelta(
+            months=-3 * self.maintenance_plan_1.interval
+        )
+        next_maintenance.request_date = past_date
+        self.assertNotEqual(
+            past_date,
+            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+        )
+        self.assertEqual(
+            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+            self.today_date
+            + relativedelta(months=2 * self.maintenance_plan_1.interval),
+        )
+        # Move the request_date far into the future:
+        future_date = self.today_date + relativedelta(
+            months=5 * self.maintenance_plan_1.interval
+        )
+        next_maintenance.request_date = future_date
+        self.assertEqual(
+            future_date,
+            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+        )
+        # Complete request in that date, next expected date should be 1 month
+        # after latest request done.:
+        next_maintenance.stage_id = self.done_stage
+        self.assertEqual(
+            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+            self.today_date
+            + relativedelta(months=6 * self.maintenance_plan_1.interval),
         )
 
     def test_generate_requests(self):


### PR DESCRIPTION
* only consider request after the start maintenance date.
* todo request ordered asc.
* add more tests.

Forward port of https://github.com/OCA/maintenance/pull/167.

@ForgeFlow