### PR TITLE
[11.0][FIX] maintenance_plan_activity: pass the res_model in the context so it is used in the team domain

### DIFF
--- a/maintenance_plan_activity/models/maintenance.py
+++ b/maintenance_plan_activity/models/maintenance.py
@@ -19,18 +19,26 @@ class MaintenanceEquipment(models.Model):
 
     def _create_new_request(self, maintenance_plan):
         new_requests = super()._create_new_request(maintenance_plan)
+        maintenance_model = self.env.ref(
+            'maintenance.model_maintenance_request')
         for request in new_requests:
             for planned_activity in maintenance_plan.planned_activity_ids:
-                self.env['mail.activity'].create({
-                    'activity_type_id': planned_activity.activity_type_id.id,
-                    'note': _('Activity automatically generated from '
-                              'maintenance plan'),
-                    'user_id': planned_activity.user_id.id or self.env.user.id,
-                    'res_id': request.id,
-                    'res_model_id': self.env.ref(
-                        'maintenance.model_maintenance_request').id,
-                    'date_deadline': fields.Date.from_string(
-                        request.schedule_date) - timedelta(
-                        days=planned_activity.date_before_request),
-                })
+                # In case mail_activty_team is installed this makes sure
+                # the correct activity team is selected. If that module is
+                # not installed the context does nothing
+                self.env['mail.activity'].with_context(
+                    default_res_model='maintenance.request').create(
+                    {
+                        'activity_type_id': planned_activity.activity_type_id.id,
+                        'note': _(
+                            'Activity automatically generated from '
+                            'maintenance plan'),
+                        'user_id': planned_activity.user_id.id or self.env.user.id,
+                        'res_id': request.id,
+                        'res_model_id': maintenance_model.id,
+                        'date_deadline': fields.Date.from_string(
+                            request.schedule_date) -
+                        timedelta(
+                            days=planned_activity.date_before_request),
+                    })
         return new_requests


### PR DESCRIPTION
Currently activities are being created for a random team because this domain is not taken the model: https://github.com/OCA/social/blob/11.0/mail_activity_team/models/mail_activity.py#L13

The only relevant change is passing the context all the rest are cosmetics to pass the flake8 checks

@ForgeFlow