### PR TITLE
[11.0][REF] convert get_relativedelta function to MaintenancePlan class method

### DIFF
--- a/maintenance_plan/data/demo_maintenance_plan.xml
+++ b/maintenance_plan/data/demo_maintenance_plan.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <odoo>
     <data noupdate="1">
         <!--  Maintenance kinds -->

--- a/maintenance_plan/models/maintenance_equipment.py
+++ b/maintenance_plan/models/maintenance_equipment.py
@@ -2,7 +2,6 @@
 # Copyright 2019 Eficent Business and IT Consulting Services, S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import _, api, fields, models
-from .maintenance_plan import get_relativedelta
 
 
 class MaintenanceEquipment(models.Model):
@@ -64,9 +63,9 @@ class MaintenanceEquipment(models.Model):
     def _create_new_request(self, maintenance_plan):
         # Compute horizon date adding to today the planning horizon
         horizon_date = fields.Date.from_string(
-            fields.Date.today()) + get_relativedelta(
-            maintenance_plan.maintenance_plan_horizon,
-            maintenance_plan.planning_step)
+            fields.Date.today()) + maintenance_plan.get_relativedelta(
+                maintenance_plan.maintenance_plan_horizon,
+                maintenance_plan.planning_step)
         # We check maintenance request already created and create until
         # planning horizon is met
         furthest_maintenance_todo = self.env['maintenance.request'].search(
@@ -74,8 +73,9 @@ class MaintenanceEquipment(models.Model):
             order="request_date desc", limit=1)
         if furthest_maintenance_todo:
             next_maintenance_date = fields.Date.from_string(
-                furthest_maintenance_todo.request_date) + get_relativedelta(
-                maintenance_plan.interval, maintenance_plan.interval_step)
+                furthest_maintenance_todo.request_date) + \
+                maintenance_plan.get_relativedelta(
+                    maintenance_plan.interval, maintenance_plan.interval_step)
         else:
             next_maintenance_date = fields.Date.from_string(
                 maintenance_plan.next_maintenance_date)
@@ -88,8 +88,9 @@ class MaintenanceEquipment(models.Model):
                     maintenance_plan, next_maintenance_date
                 )
                 requests |= self.env['maintenance.request'].create(vals)
-            next_maintenance_date = next_maintenance_date + get_relativedelta(
-                maintenance_plan.interval, maintenance_plan.interval_step)
+            next_maintenance_date = next_maintenance_date + \
+                maintenance_plan.get_relativedelta(
+                    maintenance_plan.interval, maintenance_plan.interval_step)
         return requests
 
     @api.model

--- a/maintenance_plan/models/maintenance_plan.py
+++ b/maintenance_plan/models/maintenance_plan.py
@@ -6,17 +6,6 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
-def get_relativedelta(interval, step):
-    if step == 'day':
-        return relativedelta(days=interval)
-    elif step == 'week':
-        return relativedelta(weeks=interval)
-    elif step == 'month':
-        return relativedelta(months=interval)
-    elif step == 'year':
-        return relativedelta(years=interval)
-
-
 class MaintenancePlan(models.Model):
 
     _name = 'maintenance.plan'
@@ -96,6 +85,16 @@ class MaintenancePlan(models.Model):
                 len(equipment.maintenance_ids.filtered(
                     lambda x: not x.stage_id.done))
 
+    def get_relativedelta(self, interval, step):
+        if step == 'day':
+            return relativedelta(days=interval)
+        elif step == 'week':
+            return relativedelta(weeks=interval)
+        elif step == 'month':
+            return relativedelta(months=interval)
+        elif step == 'year':
+            return relativedelta(years=interval)
+
     @api.depends(
         "interval",
         "interval_step",
@@ -106,16 +105,15 @@ class MaintenancePlan(models.Model):
     def _compute_next_maintenance(self):
         for plan in self.filtered(lambda x: x.interval > 0):
 
-            interval_timedelta = get_relativedelta(plan.interval,
-                                                   plan.interval_step)
+            interval_timedelta = self.get_relativedelta(
+                plan.interval, plan.interval_step)
 
             next_maintenance_todo = self.env["maintenance.request"].search(
-                [
-                    ("maintenance_plan_id", "=", plan.id),
-                    ("stage_id.done", "!=", True),
-                    ("close_date", "=", False),
-                    ("request_date", ">=", plan.start_maintenance_date)
-                ],
+                [("maintenance_plan_id", "=", plan.id),
+                 ("stage_id.done", "!=", True),
+                 ("close_date", "=", False),
+                 ("request_date", ">=", plan.start_maintenance_date)
+                 ],
                 order="request_date asc",
                 limit=1,
             )

--- a/maintenance_plan/tests/test_maintenance_plan.py
+++ b/maintenance_plan/tests/test_maintenance_plan.py
@@ -192,3 +192,14 @@ class TestMaintenancePlan(test_common.TransactionCase):
                 self.weekly_kind.name,
                 self.maintenance_plan_4.name)
         )
+
+    def test_get_relativedelta(self):
+        plan = self.maintenance_plan_1
+        result = plan.get_relativedelta(1, 'day')
+        self.assertEqual(relativedelta(days=1), result)
+        result = plan.get_relativedelta(1, 'week')
+        self.assertEqual(relativedelta(weeks=1), result)
+        result = plan.get_relativedelta(1, 'month')
+        self.assertEqual(relativedelta(months=1), result)
+        result = plan.get_relativedelta(1, 'year')
+        self.assertEqual(relativedelta(years=1), result)


### PR DESCRIPTION
As pointed out in #182, for me is better to have get_relativedelta as a MaintenancePlan method to allow hineritance.

PS. Proposed for v11.0 because I'm working here, but in case of success I will port it to nex versions. 