### PR TITLE
[14.0][FIX] base_maintenance_group: bug in security groups

### DIFF
--- a/base_maintenance_group/security/maintenance_security.xml
+++ b/base_maintenance_group/security/maintenance_security.xml
@@ -18,7 +18,10 @@
                 name="implied_ids"
                 eval="[(4, ref('maintenance.group_equipment_manager')), (4, ref('group_maintenance_user'))]"
             />
-            <field name="users" eval="[(4, ref('base.group_system'))]" />
+            <field
+                name="users"
+                eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+            />
         </record>
     </data>
     <data noupdate="1">


### PR DESCRIPTION
The 'users' parameter is res.users and 'base.group_system' is res.groups. Two distinct models!!! It should be base.user_root instead.