### PR TITLE
[14.0][FIX] maintenance_plan: fix new request date

### DIFF
--- a/maintenance_plan/models/maintenance_equipment.py
+++ b/maintenance_plan/models/maintenance_equipment.py
@@ -90,14 +90,20 @@ class MaintenanceEquipment(models.Model):
         )
         # We check maintenance request already created and create until
         # planning horizon is met
-        furthest_maintenance_todo = self.env["maintenance.request"].search(
-            [("maintenance_plan_id", "=", mtn_plan.id)],
+        start_maintenance_date_plan = fields.Date.from_string(
+            mtn_plan.start_maintenance_date
+        )
+        furthest_maintenance_request = self.env["maintenance.request"].search(
+            [
+                ("maintenance_plan_id", "=", mtn_plan.id),
+                ("request_date", ">=", start_maintenance_date_plan),
+            ],
             order="request_date desc",
             limit=1,
         )
-        if furthest_maintenance_todo:
+        if furthest_maintenance_request:
             next_maintenance_date = fields.Date.from_string(
-                furthest_maintenance_todo.request_date
+                furthest_maintenance_request.request_date
             ) + mtn_plan.get_relativedelta(mtn_plan.interval, mtn_plan.interval_step)
         else:
             next_maintenance_date = fields.Date.from_string(

--- a/maintenance_plan/tests/test_maintenance_plan.py
+++ b/maintenance_plan/tests/test_maintenance_plan.py
@@ -210,6 +210,40 @@ class TestMaintenancePlan(test_common.TransactionCase):
             % (self.weekly_kind.name, self.maintenance_plan_4.name),
         )
 
+    def test_generate_requests2(self):
+        self.cron.method_direct_trigger()
+        generated_requests = self.maintenance_request_obj.search(
+            [("maintenance_plan_id", "=", self.maintenance_plan_1.id)],
+            order="schedule_date asc",
+        )
+
+        self.assertEqual(len(generated_requests), 3)
+
+        # We set plan start_maintenanca_date to a future one. New requests should take
+        # into account this new date.
+
+        self.maintenance_plan_1.write(
+            {
+                "start_maintenance_date": fields.Date.to_string(
+                    self.today_date + timedelta(weeks=9)
+                ),
+                "maintenance_plan_horizon": 3,
+            }
+        )
+
+        self.cron.method_direct_trigger()
+
+        generated_requests = self.maintenance_request_obj.search(
+            [("maintenance_plan_id", "=", self.maintenance_plan_1.id)],
+            order="schedule_date asc",
+        )
+
+        self.assertEqual(len(generated_requests), 4)
+        self.assertEqual(
+            fields.Date.from_string(generated_requests[-1].request_date),
+            self.today_date + relativedelta(weeks=9),
+        )
+
     def test_get_relativedelta(self):
         plan = self.maintenance_plan_1
         result = plan.get_relativedelta(1, "day")

--- a/maintenance_plan/views/maintenance_equipment_views.xml
+++ b/maintenance_plan/views/maintenance_equipment_views.xml
@@ -82,4 +82,16 @@
     <record id="maintenance.hr_equipment_action" model="ir.actions.act_window">
         <field name="context">{'hide_equipment_id': 1}</field>
     </record>
+
+    <record id="hr_equipment_request_view_tree" model="ir.ui.view">
+        <field name="name">equipment.request.tree</field>
+        <field name="model">maintenance.request</field>
+        <field name="inherit_id" ref="maintenance.hr_equipment_request_view_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="field[@name='request_date']" position="attributes">
+                    <attribute name="groups" />
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
When changing the start date of a plan (and setting it to a future one) new requests date weren't created as expected.

@ForgeFlow
