### PR TITLE
[14.0][FIX] maintenance_plan: avoid error if planning_step is not defined

### DIFF
--- a/maintenance_plan/models/maintenance_equipment.py
+++ b/maintenance_plan/models/maintenance_equipment.py
@@ -56,9 +56,9 @@ class MaintenanceEquipment(models.Model):
                 )
 
     def _prepare_request_from_plan(self, maintenance_plan, next_maintenance_date):
-        team = maintenance_plan.maintenance_team_id.id or self.maintenance_team_id.id
-        if not team:
-            team = self.env["maintenance.request"]._get_default_team_id()
+        team_id = maintenance_plan.maintenance_team_id.id or self.maintenance_team_id.id
+        if not team_id:
+            team_id = self.env["maintenance.request"]._get_default_team_id()
 
         description = self.name if self else maintenance_plan.name
         kind = maintenance_plan.maintenance_kind_id.name or _("Unspecified kind")
@@ -73,7 +73,7 @@ class MaintenanceEquipment(models.Model):
             "maintenance_type": "preventive",
             "owner_user_id": self.owner_user_id.id or self.env.user.id,
             "user_id": self.technician_user_id.id,
-            "maintenance_team_id": team,
+            "maintenance_team_id": team_id,
             "maintenance_kind_id": maintenance_plan.maintenance_kind_id.id,
             "maintenance_plan_id": maintenance_plan.id,
             "duration": maintenance_plan.duration,
@@ -83,16 +83,12 @@ class MaintenanceEquipment(models.Model):
 
     def _create_new_request(self, mtn_plan):
         # Compute horizon date adding to today the planning horizon
-        horizon_date = fields.Date.from_string(
-            fields.Date.today()
-        ) + mtn_plan.get_relativedelta(
-            mtn_plan.maintenance_plan_horizon, mtn_plan.planning_step
+        horizon_date = fields.Date.today() + mtn_plan.get_relativedelta(
+            mtn_plan.maintenance_plan_horizon, mtn_plan.planning_step or "year"
         )
         # We check maintenance request already created and create until
         # planning horizon is met
-        start_maintenance_date_plan = fields.Date.from_string(
-            mtn_plan.start_maintenance_date
-        )
+        start_maintenance_date_plan = mtn_plan.start_maintenance_date
         furthest_maintenance_request = self.env["maintenance.request"].search(
             [
                 ("maintenance_plan_id", "=", mtn_plan.id),
@@ -102,21 +98,22 @@ class MaintenanceEquipment(models.Model):
             limit=1,
         )
         if furthest_maintenance_request:
-            next_maintenance_date = fields.Date.from_string(
+            next_maintenance_date = (
                 furthest_maintenance_request.request_date
-            ) + mtn_plan.get_relativedelta(mtn_plan.interval, mtn_plan.interval_step)
-        else:
-            next_maintenance_date = fields.Date.from_string(
-                mtn_plan.next_maintenance_date
+                + mtn_plan.get_relativedelta(
+                    mtn_plan.interval, mtn_plan.interval_step or "year"
+                )
             )
+        else:
+            next_maintenance_date = mtn_plan.next_maintenance_date
         requests = self.env["maintenance.request"]
         # Create maintenance request until we reach planning horizon
         while next_maintenance_date <= horizon_date:
-            if next_maintenance_date >= fields.Date.from_string(fields.Date.today()):
+            if next_maintenance_date >= fields.Date.today():
                 vals = self._prepare_request_from_plan(mtn_plan, next_maintenance_date)
                 requests |= self.env["maintenance.request"].create(vals)
             next_maintenance_date = next_maintenance_date + mtn_plan.get_relativedelta(
-                mtn_plan.interval, mtn_plan.interval_step
+                mtn_plan.interval, mtn_plan.interval_step or "year"
             )
         return requests
 

--- a/maintenance_plan/tests/test_maintenance_plan.py
+++ b/maintenance_plan/tests/test_maintenance_plan.py
@@ -5,11 +5,11 @@ from datetime import timedelta
 
 from dateutil.relativedelta import relativedelta
 
-import odoo.tests.common as test_common
 from odoo import _, fields
+from odoo.tests import common
 
 
-class TestMaintenancePlan(test_common.TransactionCase):
+class TestMaintenancePlan(common.TransactionCase):
     def setUp(self):
         super().setUp()
         self.env = self.env(
@@ -26,12 +26,11 @@ class TestMaintenancePlan(test_common.TransactionCase):
         self.done_stage = self.env.ref("maintenance.stage_3")
 
         self.equipment_1 = self.maintenance_equipment_obj.create({"name": "Laptop 1"})
-        today = fields.Date.today()
-        self.today_date = fields.Date.from_string(today)
+        self.today_date = fields.Date.today()
         self.maintenance_plan_1 = self.maintenance_plan_obj.create(
             {
                 "equipment_id": self.equipment_1.id,
-                "start_maintenance_date": today,
+                "start_maintenance_date": self.today_date,
                 "interval": 1,
                 "interval_step": "month",
                 "maintenance_plan_horizon": 2,
@@ -99,8 +98,8 @@ class TestMaintenancePlan(test_common.TransactionCase):
         self.maintenance_plan_1._compute_next_maintenance()
         # Check next maintenance date is 1 month from start date
         self.assertEqual(
-            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
-            fields.Date.from_string(self.maintenance_plan_1.start_maintenance_date)
+            self.maintenance_plan_1.next_maintenance_date,
+            self.maintenance_plan_1.start_maintenance_date
             + relativedelta(months=self.maintenance_plan_1.interval),
         )
 
@@ -112,22 +111,22 @@ class TestMaintenancePlan(test_common.TransactionCase):
         )
         self.assertEqual(len(generated_requests), 3)
         next_maintenance = generated_requests[0]
-        next_date = fields.Date.from_string(next_maintenance.request_date)
+        next_date = next_maintenance.request_date
         # First maintenance was planned today:
         self.assertEqual(next_date, self.today_date)
         self.assertEqual(
             next_date,
-            fields.Date.from_string(self.maintenance_plan_1.start_maintenance_date),
+            self.maintenance_plan_1.start_maintenance_date,
         )
         self.assertEqual(
             next_date,
-            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+            self.maintenance_plan_1.next_maintenance_date,
         )
         # Complete request:
         next_maintenance.stage_id = self.done_stage
         # Check next one:
         next_maintenance = generated_requests[1]
-        next_date = fields.Date.from_string(next_maintenance.request_date)
+        next_date = next_maintenance.request_date
         # This should be expected next month:
         self.assertEqual(
             next_date,
@@ -135,12 +134,12 @@ class TestMaintenancePlan(test_common.TransactionCase):
         )
         self.assertEqual(
             next_date,
-            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+            self.maintenance_plan_1.next_maintenance_date,
         )
         # Complete request and Check next one:
         next_maintenance.stage_id = self.done_stage
         next_maintenance = generated_requests[2]
-        next_date = fields.Date.from_string(next_maintenance.request_date)
+        next_date = next_maintenance.request_date
         # This one should be expected in 2 months:
         self.assertEqual(
             next_date,
@@ -149,7 +148,7 @@ class TestMaintenancePlan(test_common.TransactionCase):
         )
         self.assertEqual(
             next_date,
-            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+            self.maintenance_plan_1.next_maintenance_date,
         )
         # Move it to a date before `start_maintenance_date` (the request should
         # be ignored)
@@ -159,10 +158,10 @@ class TestMaintenancePlan(test_common.TransactionCase):
         next_maintenance.request_date = past_date
         self.assertNotEqual(
             past_date,
-            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+            self.maintenance_plan_1.next_maintenance_date,
         )
         self.assertEqual(
-            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+            self.maintenance_plan_1.next_maintenance_date,
             self.today_date
             + relativedelta(months=2 * self.maintenance_plan_1.interval),
         )
@@ -173,13 +172,13 @@ class TestMaintenancePlan(test_common.TransactionCase):
         next_maintenance.request_date = future_date
         self.assertEqual(
             future_date,
-            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+            self.maintenance_plan_1.next_maintenance_date,
         )
         # Complete request in that date, next expected date should be 1 month
         # after latest request done.:
         next_maintenance.stage_id = self.done_stage
         self.assertEqual(
-            fields.Date.from_string(self.maintenance_plan_1.next_maintenance_date),
+            self.maintenance_plan_1.next_maintenance_date,
             self.today_date
             + relativedelta(months=6 * self.maintenance_plan_1.interval),
         )
@@ -197,7 +196,7 @@ class TestMaintenancePlan(test_common.TransactionCase):
 
         for req in generated_requests:
             self.assertEqual(
-                fields.Date.from_string(req.schedule_date), request_date_schedule
+                fields.Date.to_date(req.schedule_date), request_date_schedule
             )
             request_date_schedule = request_date_schedule + relativedelta(months=1)
 
@@ -240,7 +239,7 @@ class TestMaintenancePlan(test_common.TransactionCase):
 
         self.assertEqual(len(generated_requests), 4)
         self.assertEqual(
-            fields.Date.from_string(generated_requests[-1].request_date),
+            generated_requests[-1].request_date,
             self.today_date + relativedelta(weeks=9),
         )
 

--- a/maintenance_plan_activity/__manifest__.py
+++ b/maintenance_plan_activity/__manifest__.py
@@ -10,7 +10,7 @@
     "version": "14.0.1.0.1",
     "license": "AGPL-3",
     "author": "ForgeFlow, Odoo Community Association (OCA)",
-    "maintainers": ["AdriaGForgeFlow"],
+    "maintainers": [],
     "website": "https://github.com/OCA/maintenance",
     "depends": ["maintenance_plan"],
     "data": ["security/ir.model.access.csv", "views/maintenance_views.xml"],

--- a/maintenance_plan_activity/models/maintenance.py
+++ b/maintenance_plan_activity/models/maintenance.py
@@ -21,7 +21,7 @@ class MaintenanceEquipment(models.Model):
         new_requests = super()._create_new_request(maintenance_plan)
         for request in new_requests:
             for planned_activity in maintenance_plan.planned_activity_ids:
-                # In case mail_activty_team is installed this makes sure
+                # In case mail_activity_team is installed this makes sure
                 # the correct activity team is selected. If that module is
                 # not installed the context does nothing
                 self.env["mail.activity"].with_context(
@@ -30,14 +30,14 @@ class MaintenanceEquipment(models.Model):
                     {
                         "activity_type_id": planned_activity.activity_type_id.id,
                         "note": _(
-                            "Activity automatically generated from " "maintenance plan"
+                            "Activity automatically generated from maintenance plan"
                         ),
                         "user_id": planned_activity.user_id.id or self.env.user.id,
                         "res_id": request.id,
                         "res_model_id": self.env.ref(
                             "maintenance.model_maintenance_request"
                         ).id,
-                        "date_deadline": fields.Date.from_string(request.schedule_date)
+                        "date_deadline": request.schedule_date
                         - timedelta(days=planned_activity.date_before_request),
                     }
                 )

--- a/maintenance_plan_activity/tests/test_maintenance_plan_activity.py
+++ b/maintenance_plan_activity/tests/test_maintenance_plan_activity.py
@@ -57,5 +57,5 @@ class TestMaintenancePlanActivity(test_common.TransactionCase):
         self.assertEqual(generated_activities[0].activity_type_id.name, self.call.name)
         self.assertEqual(
             generated_activities[0].date_deadline,
-            fields.Date.from_string(request_1.schedule_date) - timedelta(days=2),
+            fields.Date.to_date(request_1.schedule_date) - timedelta(days=2),
         )


### PR DESCRIPTION
Also, clean-up of useless from_string() calls.