### PR TITLE
[15.0][FIX] maintenance_plan: avoid error if planning_step is not defined

### DIFF
--- a/maintenance_plan_activity/__manifest__.py
+++ b/maintenance_plan_activity/__manifest__.py
@@ -10,7 +10,7 @@
     "version": "15.0.1.0.1",
     "license": "AGPL-3",
     "author": "ForgeFlow, Odoo Community Association (OCA)",
-    "maintainers": ["AdriaGForgeFlow"],
+    "maintainers": [],
     "website": "https://github.com/OCA/maintenance",
     "depends": ["maintenance_plan"],
     "data": ["security/ir.model.access.csv", "views/maintenance_views.xml"],

--- a/maintenance_plan_activity/models/maintenance.py
+++ b/maintenance_plan_activity/models/maintenance.py
@@ -21,7 +21,7 @@ class MaintenanceEquipment(models.Model):
         new_requests = super()._create_new_request(maintenance_plan)
         for request in new_requests:
             for planned_activity in maintenance_plan.planned_activity_ids:
-                # In case mail_activty_team is installed this makes sure
+                # In case mail_activity_team is installed this makes sure
                 # the correct activity team is selected. If that module is
                 # not installed the context does nothing
                 self.env["mail.activity"].with_context(
@@ -30,14 +30,14 @@ class MaintenanceEquipment(models.Model):
                     {
                         "activity_type_id": planned_activity.activity_type_id.id,
                         "note": _(
-                            "Activity automatically generated from " "maintenance plan"
+                            "Activity automatically generated from maintenance plan"
                         ),
                         "user_id": planned_activity.user_id.id or self.env.user.id,
                         "res_id": request.id,
                         "res_model_id": self.env.ref(
                             "maintenance.model_maintenance_request"
                         ).id,
-                        "date_deadline": fields.Date.from_string(request.schedule_date)
+                        "date_deadline": request.schedule_date
                         - timedelta(days=planned_activity.date_before_request),
                     }
                 )

--- a/maintenance_plan_activity/tests/test_maintenance_plan_activity.py
+++ b/maintenance_plan_activity/tests/test_maintenance_plan_activity.py
@@ -57,5 +57,5 @@ class TestMaintenancePlanActivity(test_common.TransactionCase):
         self.assertEqual(generated_activities[0].activity_type_id.name, self.call.name)
         self.assertEqual(
             generated_activities[0].date_deadline,
-            fields.Date.from_string(request_1.schedule_date) - timedelta(days=2),
+            fields.Date.to_date(request_1.schedule_date) - timedelta(days=2),
         )


### PR DESCRIPTION
Also, clean-up of useless from_string() calls.

This is a forward port of https://github.com/OCA/maintenance/pull/232.