### PR TITLE
[12.0][FIX] maintenance_plan generate requests for inactive equipment

### DIFF
--- a/maintenance_plan/models/maintenance_equipment.py
+++ b/maintenance_plan/models/maintenance_equipment.py
@@ -103,7 +103,9 @@ class MaintenanceEquipment(models.Model):
             today if none exists
         """
         for plan in self.env['maintenance.plan'].sudo().search(
-                [('interval', '>', 0)]):
+                [('interval', '>', 0)]).filtered(
+            lambda x: True if not x.equipment_id else x.equipment_id.active
+        ):
             equipment = plan.equipment_id
             equipment._create_new_request(plan)
 

--- a/maintenance_plan/tests/test_maintenance_plan.py
+++ b/maintenance_plan/tests/test_maintenance_plan.py
@@ -231,3 +231,12 @@ class TestMaintenancePlan(test_common.TransactionCase):
         self.assertEqual(relativedelta(months=1), result)
         result = plan.get_relativedelta(1, 'year')
         self.assertEqual(relativedelta(years=1), result)
+
+    def test_generate_requests_inactive_equipment(self):
+        self.equipment_1.active = False
+        self.cron.method_direct_trigger()
+        generated_requests = self.maintenance_request_obj.search(
+            [('maintenance_plan_id', '=', self.maintenance_plan_1.id)],
+            order="schedule_date asc"
+        )
+        self.assertEqual(len(generated_requests), 0)

--- a/maintenance_plan/tests/test_maintenance_plan.py
+++ b/maintenance_plan/tests/test_maintenance_plan.py
@@ -240,3 +240,10 @@ class TestMaintenancePlan(test_common.TransactionCase):
             order="schedule_date asc"
         )
         self.assertEqual(len(generated_requests), 0)
+        self.equipment_1.active = True
+        self.cron.method_direct_trigger()
+        generated_requests = self.maintenance_request_obj.search(
+            [('maintenance_plan_id', '=', self.maintenance_plan_1.id)],
+            order="schedule_date asc"
+        )
+        self.assertEqual(len(generated_requests), 3)


### PR DESCRIPTION
Bug: maintenance plan cron create requests for inactive equipment.
This PR solve the problem.
[First commit show error, second commit solve it, they will be squashed before merging.]