### PR TITLE
[14.0] [IMP] maintenance_equipment_status: Make status name translatable

### DIFF
--- a/maintenance_equipment_status/models/maintenance_equipment_status.py
+++ b/maintenance_equipment_status/models/maintenance_equipment_status.py
@@ -10,7 +10,7 @@ class MaintenanceEquipmentStatus(models.Model):
     _order = "sequence"
 
     active = fields.Boolean(default=True)
-    name = fields.Char("Name")
+    name = fields.Char("Name", translate=True)
     note = fields.Text("Notes")
     sequence = fields.Integer(string="Sequence", default=10)
     category_ids = fields.Many2many(


### PR DESCRIPTION
Simple change to make the status' name translatable