### PR TITLE
[16.0][FIX] maintenance_equipment_hierarchy - children smartbutton leads wrongly to parent equipment

### DIFF
--- a/maintenance_equipment_hierarchy/models/maintenance_equipment.py
+++ b/maintenance_equipment_hierarchy/models/maintenance_equipment.py
@@ -58,7 +58,6 @@ class MaintenanceEquipment(models.Model):
             "name": _("Child equipment of %s") % self.name,
             "type": "ir.actions.act_window",
             "res_model": "maintenance.equipment",
-            "res_id": self.id,
             "view_mode": "list,form",
             "context": {
                 **self.env.context,


### PR DESCRIPTION
When you are on a parent equipment form with a child equipment, and you click on the children smartbutton...
![formparentwithsmartbutton](https://user-images.githubusercontent.com/32102436/207300918-fec5dcc4-4109-4f53-b62e-aa894462a7bf.png)

you reach a tree view with children equipments...

![screenaftersmartbutton](https://user-images.githubusercontent.com/32102436/207301275-2379872e-17d3-4c49-ab12-132edf0dda30.png)

when you click on any equipments there, you should reach the form of this equipment. But instead, you go back to the parent equipment form.

![myparentform](https://user-images.githubusercontent.com/32102436/207301428-52de023f-1955-43d9-8278-6c01536fdb7f.png)

This fix corrects this behaviour, correctly reaching the child equipment when clicking on it.

![enfantform](https://user-images.githubusercontent.com/32102436/207301566-6e7265d8-2c8b-4763-a517-004a9fb4804c.png)