### PR TITLE
[IMP] maintenance_account: only create Equipments on purchase documents

### DIFF
--- a/maintenance_account/models/account_move.py
+++ b/maintenance_account/models/account_move.py
@@ -20,7 +20,7 @@ class AccountMove(models.Model):
     def action_post(self):
         super().action_post()
         equipment_model = self.env["maintenance.equipment"]
-        for move in self:
+        for move in self.filtered(lambda r: r.is_purchase_document()):
             for line in move.line_ids.filtered(
                 lambda x: (
                     not x.equipment_ids


### PR DESCRIPTION
When creating an account move for sale with a product that is maintenance, an equipment was created. With the new changes, this shouldn't happen.

Added a test for it.