### PR TITLE
[13.0][FIX] maintenance_plan: Display the maintenance_plan_ids field correctly.

### DIFF
--- a/maintenance_plan/views/maintenance_equipment_views.xml
+++ b/maintenance_plan/views/maintenance_equipment_views.xml
@@ -23,7 +23,7 @@
             <xpath expr="//group[@name='maintenance']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
-            <xpath expr="//group[@name='maintenance']" position="after">
+            <xpath expr="//group[@name='maintenance']/.." position="after">
                 <group name="maintenance_plans">
                     <field
                         name="maintenance_plan_ids"


### PR DESCRIPTION
Display the `maintenance_plan_ids` field correctly.

**Before**
![antes](https://user-images.githubusercontent.com/4117568/208871638-8d4b856a-d9fb-48ce-900c-934d0544149d.png)

**After**
![despues](https://user-images.githubusercontent.com/4117568/208871660-65ef8fb5-7cec-4a26-88db-fb0b3847d0c5.png)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT40881