### PR TITLE
[14.0][FIX] maintenance_plan: Avoid multiple notebooks

### DIFF
--- a/maintenance_plan/__manifest__.py
+++ b/maintenance_plan/__manifest__.py
@@ -9,7 +9,7 @@
     "category": "Maintenance",
     "website": "https://github.com/OCA/maintenance",
     "images": [],
-    "depends": ["maintenance"],
+    "depends": ["base_maintenance"],
     "data": [
         "security/ir.model.access.csv",
         "security/maintenance_security.xml",

--- a/maintenance_plan/views/maintenance_equipment_views.xml
+++ b/maintenance_plan/views/maintenance_equipment_views.xml
@@ -63,25 +63,22 @@
         <field name="name">equipment.request.form.inherit</field>
         <field name="model">maintenance.request</field>
         <field name="priority" eval="999" />
-        <field name="inherit_id" ref="maintenance.hr_equipment_request_view_form" />
+        <field name="inherit_id" ref="base_maintenance.equipment_request_view_form" />
         <field name="arch" type="xml">
             <field name="maintenance_type" position="after">
                 <field name="maintenance_kind_id" />
             </field>
-            <!-- TODO: Use position="move" instead -->
-            <field name="description" position="replace">
-                <notebook>
-                    <page string="Instructions">
-                        <field
-                            name="note"
-                            placeholder="Describe the maintenance to do..."
-                        />
-                    </page>
-                    <page string="Notes">
-                        <field name="description" placeholder="Internal notes..." />
-                    </page>
-                </notebook>
-            </field>
+            <notebook position="inside">
+                <page string="Instructions">
+                    <field
+                        name="note"
+                        placeholder="Describe the maintenance to do..."
+                    />
+                </page>
+                <page string="Notes">
+                    <field name="description" placeholder="Internal notes..." />
+                </page>
+            </notebook>
         </field>
     </record>
     <record id="maintenance.hr_equipment_action" model="ir.actions.act_window">


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/maintenance/pull/272

Avoid multiple notebooks (if `maintenance_timesheet` is installed).

**Before**
![antes](https://user-images.githubusercontent.com/4117568/209306865-20a11c69-f527-4663-a2bd-27f85bcfe5c3.png)

**After**
![despues](https://user-images.githubusercontent.com/4117568/209306880-82961fb4-6a85-4d27-a1bb-f37b966ad2d1.png)

Since https://github.com/OCA/maintenance/pull/270

Please @pedrobaeza and @ernestotejeda can you review it?

@Tecnativa TT40881