### PR TITLE
[15.0][IMP] base_maintenance: Replace description field from request form view to <notebook> structure to be inherited by other modules

### DIFF
--- a/base_maintenance/views/maintenance_request_views.xml
+++ b/base_maintenance/views/maintenance_request_views.xml
@@ -6,6 +6,7 @@
         <field name="name">equipment.request.form</field>
         <field name="model">maintenance.request</field>
         <field name="inherit_id" ref="maintenance.hr_equipment_request_view_form" />
+        <field name="priority" eval="999" />
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_title')]" position="before">
                 <div
@@ -16,6 +17,13 @@
                     <!--Empty, to be inherited by other modules.-->
                 </div>
             </xpath>
+            <field name="description" position="replace">
+                <notebook>
+                    <page name="description_page" string="Description">
+                        <field name="description" />
+                    </page>
+                </notebook>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/maintenance/pull/271

Replace description field from request form view to <notebook> structure to be inherited by other modules

Please @pedrobaeza and @ernestotejeda can you review it?

@Tecnativa TT40881