### PR TITLE
[13.0][IMP] maintenance_plan: Add Generate preventive maintenance requests button from plan view form.

### DIFF
--- a/maintenance_plan/i18n/es.po
+++ b/maintenance_plan/i18n/es.po
@@ -104,10 +104,20 @@ msgid "Frequency"
 msgstr "Frecuencia"
 
 #. module: maintenance_plan
+#: model_terms:ir.ui.view,arch_db:maintenance_plan.maintenance_plan_view_form
+msgid "Generate requests for current threshold"
+msgstr "Generar peticiones para el umbral actual"
+
+#. module: maintenance_plan
 #: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_kind__id
 #: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_plan__id
 msgid "ID"
 msgstr "ID"
+
+#. module: maintenance_plan
+#: model_terms:ir.ui.view,arch_db:maintenance_plan.maintenance_plan_view_form
+msgid "If not clicked, the scheduled action will do it for you."
+msgstr "Si no se hace click, la acción programada lo hará por usted."
 
 #. module: maintenance_plan
 #: model_terms:ir.ui.view,arch_db:maintenance_plan.maintenance_plan_view_search

--- a/maintenance_plan/i18n/maintenance_plan.pot
+++ b/maintenance_plan/i18n/maintenance_plan.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-02-17 08:23+0000\n"
+"PO-Revision-Date: 2023-02-17 08:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -100,9 +102,19 @@ msgid "Frequency"
 msgstr ""
 
 #. module: maintenance_plan
+#: model_terms:ir.ui.view,arch_db:maintenance_plan.maintenance_plan_view_form
+msgid "Generate requests for current threshold"
+msgstr ""
+
+#. module: maintenance_plan
 #: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_kind__id
 #: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_plan__id
 msgid "ID"
+msgstr ""
+
+#. module: maintenance_plan
+#: model_terms:ir.ui.view,arch_db:maintenance_plan.maintenance_plan_view_form
+msgid "If not clicked, the scheduled action will do it for you."
 msgstr ""
 
 #. module: maintenance_plan

--- a/maintenance_plan/models/maintenance_plan.py
+++ b/maintenance_plan/models/maintenance_plan.py
@@ -197,3 +197,10 @@ class MaintenancePlan(models.Model):
             "equipment maintenance plan.",
         )
     ]
+
+    def button_manual_request_generation(self):
+        """Call the same method that the cron for generating manually the maintenance
+        requests."""
+        for plan in self:
+            equipment = plan.equipment_id
+            equipment._create_new_request(plan)

--- a/maintenance_plan/tests/test_maintenance_plan.py
+++ b/maintenance_plan/tests/test_maintenance_plan.py
@@ -279,3 +279,8 @@ class TestMaintenancePlan(test_common.TransactionCase):
             "base_maintenance.report_maintenance_request"
         ).render_qweb_text(generated_request.ids, False)
         self.assertRegex(str(res[0]), "TEST-INSTRUCTIONS")
+
+    def test_maintenance_plan_button_manual_request_generation(self):
+        self.assertEqual(len(self.maintenance_plan_1.maintenance_ids), 0)
+        self.maintenance_plan_1.button_manual_request_generation()
+        self.assertEqual(len(self.maintenance_plan_1.maintenance_ids), 3)

--- a/maintenance_plan/views/maintenance_plan_views.xml
+++ b/maintenance_plan/views/maintenance_plan_views.xml
@@ -15,6 +15,15 @@
         <field name="model">maintenance.plan</field>
         <field name="arch" type="xml">
             <form string="Maintenance Plan">
+                <header>
+                    <button
+                        name="button_manual_request_generation"
+                        string="Generate requests for current threshold"
+                        help="If not clicked, the scheduled action will do it for you."
+                        type="object"
+                        attrs="{'invisible' : ['|', ('id', '=', False),('interval', '=', 0)]}"
+                    />
+                </header>
                 <sheet>
                     <widget
                         name="web_ribbon"


### PR DESCRIPTION
Add Generate preventive maintenance requests button from plan view form

Add button from maintenance plan to allow generate maintenance requests without waiting for cron.

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT41729