### PR TITLE
[15.0][IMP] maintenance_plan: Add Generate preventive maintenance requests button from plan view form

### DIFF
--- a/maintenance_plan/i18n/es.po
+++ b/maintenance_plan/i18n/es.po
@@ -154,6 +154,12 @@ msgid "Has Message"
 msgstr "Tiene mensaje"
 
 #. module: maintenance_plan
+#: model_terms:ir.ui.view,arch_db:maintenance_plan.maintenance_plan_view_form
+msgid "Generate requests for current threshold"
+msgstr "Generar peticiones para el umbral actual"
+
+#. module: maintenance_plan
+#: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_equipment__id
 #: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_kind__id
 #: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_plan__id
 msgid "ID"
@@ -491,7 +497,7 @@ msgstr "Usuario responsable"
 #. module: maintenance_plan
 #: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_plan__message_has_sms_error
 msgid "SMS Delivery error"
-msgstr ""
+msgstr "Error de envío SMS"
 
 #. module: maintenance_plan
 #: code:addons/maintenance_plan/models/maintenance_equipment.py:0
@@ -580,16 +586,6 @@ msgstr "Contador de mensajes sin leer"
 #: code:addons/maintenance_plan/models/maintenance_equipment.py:0
 #, python-format
 msgid "Unspecified kind"
-msgstr ""
-
-#. module: maintenance_plan
-#: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_plan__website_message_ids
-msgid "Website Messages"
-msgstr ""
-
-#. module: maintenance_plan
-#: model:ir.model.fields,help:maintenance_plan.field_maintenance_plan__website_message_ids
-msgid "Website communication history"
 msgstr ""
 
 #. module: maintenance_plan

--- a/maintenance_plan/i18n/maintenance_plan.pot
+++ b/maintenance_plan/i18n/maintenance_plan.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-02-21 15:19+0000\n"
+"PO-Revision-Date: 2023-02-21 15:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -150,6 +152,12 @@ msgid "Has Message"
 msgstr ""
 
 #. module: maintenance_plan
+#: model_terms:ir.ui.view,arch_db:maintenance_plan.maintenance_plan_view_form
+msgid "Generate requests for current threshold"
+msgstr ""
+
+#. module: maintenance_plan
+#: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_equipment__id
 #: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_kind__id
 #: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_plan__id
 msgid "ID"
@@ -175,6 +183,11 @@ msgstr ""
 #: model:ir.model.fields,help:maintenance_plan.field_maintenance_plan__message_has_error
 #: model:ir.model.fields,help:maintenance_plan.field_maintenance_plan__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: maintenance_plan
+#: model_terms:ir.ui.view,arch_db:maintenance_plan.maintenance_plan_view_form
+msgid "If not clicked, the scheduled action will do it for you."
 msgstr ""
 
 #. module: maintenance_plan
@@ -569,16 +582,6 @@ msgstr ""
 #: code:addons/maintenance_plan/models/maintenance_equipment.py:0
 #, python-format
 msgid "Unspecified kind"
-msgstr ""
-
-#. module: maintenance_plan
-#: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_plan__website_message_ids
-msgid "Website Messages"
-msgstr ""
-
-#. module: maintenance_plan
-#: model:ir.model.fields,help:maintenance_plan.field_maintenance_plan__website_message_ids
-msgid "Website communication history"
 msgstr ""
 
 #. module: maintenance_plan

--- a/maintenance_plan/models/maintenance_plan.py
+++ b/maintenance_plan/models/maintenance_plan.py
@@ -200,3 +200,10 @@ class MaintenancePlan(models.Model):
             "equipment maintenance plan.",
         )
     ]
+
+    def button_manual_request_generation(self):
+        """Call the same method that the cron for generating manually the maintenance
+        requests."""
+        for plan in self:
+            equipment = plan.equipment_id
+            equipment._create_new_request(plan)

--- a/maintenance_plan/tests/test_maintenance_plan.py
+++ b/maintenance_plan/tests/test_maintenance_plan.py
@@ -290,3 +290,8 @@ class TestMaintenancePlan(common.TransactionCase):
             "base_maintenance.report_maintenance_request"
         )._render_qweb_text(generated_request.ids, False)
         self.assertRegex(str(res[0]), "TEST-INSTRUCTIONS")
+
+    def test_maintenance_plan_button_manual_request_generation(self):
+        self.assertEqual(len(self.maintenance_plan_1.maintenance_ids), 0)
+        self.maintenance_plan_1.button_manual_request_generation()
+        self.assertEqual(len(self.maintenance_plan_1.maintenance_ids), 3)

--- a/maintenance_plan/views/maintenance_plan_views.xml
+++ b/maintenance_plan/views/maintenance_plan_views.xml
@@ -15,6 +15,15 @@
         <field name="model">maintenance.plan</field>
         <field name="arch" type="xml">
             <form string="Maintenance Plan">
+                <header>
+                    <button
+                        name="button_manual_request_generation"
+                        string="Generate requests for current threshold"
+                        help="If not clicked, the scheduled action will do it for you."
+                        type="object"
+                        attrs="{'invisible' : ['|', ('id', '=', False),('interval', '=', 0)]}"
+                    />
+                </header>
                 <sheet>
                     <widget
                         name="web_ribbon"


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/maintenance/pull/300

Add Generate preventive maintenance requests button from plan view form

Add button from maintenance plan to allow generate maintenance requests without waiting for cron.

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT41729