### PR TITLE
[15.0][IMP] maintenance_plan: Set planned_hours in request from plan if maintenance_timesheet is installed

### DIFF
--- a/maintenance_plan/models/maintenance_equipment.py
+++ b/maintenance_plan/models/maintenance_equipment.py
@@ -56,8 +56,9 @@ class MaintenanceEquipment(models.Model):
 
     def _prepare_request_from_plan(self, maintenance_plan, next_maintenance_date):
         team_id = maintenance_plan.maintenance_team_id.id or self.maintenance_team_id.id
+        request_model = self.env["maintenance.request"]
         if not team_id:
-            team_id = self.env["maintenance.request"]._get_default_team_id()
+            team_id = request_model._get_default_team_id()
 
         description = self.name if self else maintenance_plan.name
         kind = maintenance_plan.maintenance_kind_id.name or _("Unspecified kind")
@@ -67,7 +68,7 @@ class MaintenanceEquipment(models.Model):
             description=description,
         )
 
-        return {
+        data = {
             "name": name,
             "request_date": next_maintenance_date,
             "schedule_date": next_maintenance_date,
@@ -83,6 +84,10 @@ class MaintenanceEquipment(models.Model):
             "note": maintenance_plan.note,
             "company_id": maintenance_plan.company_id.id or self.company_id.id,
         }
+        # This field comes from maintenance_timesheet for avoiding a glue module
+        if "planned_hours" in request_model._fields:
+            data["planned_hours"] = maintenance_plan.duration
+        return data
 
     def _create_new_request(self, mtn_plan):
         # Compute horizon date adding to today the planning horizon


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/maintenance/pull/304

Set `planned_hours` in request from plan if `maintenance_timesheet` is installed.

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa