### PR TITLE
[14.0][FIX] maintenance_account /maintenance_purchase: check before creation

### DIFF
--- a/maintenance_account/models/account_move.py
+++ b/maintenance_account/models/account_move.py
@@ -100,11 +100,14 @@ class AccountMoveLine(models.Model):
 
     def _set_equipment_category(self):
         if not self.equipment_category_id:
-            # Prevent error if user does not have permission to create equipments
             category_model = self.env["maintenance.equipment.category"].sudo()
-            category = category_model.with_company(self.company_id).create(
-                self._prepare_equipment_category_vals()
+            category = fields.first(
+                self.product_id.product_tmpl_id.categ_id.equipment_category_ids
             )
+            if not category:
+                category = category_model.create(
+                    self._prepare_equipment_category_vals()
+                )
             self.equipment_category_id = category.id
 
     def _prepare_equipment_vals(self):

--- a/maintenance_purchase/models/purchase_order.py
+++ b/maintenance_purchase/models/purchase_order.py
@@ -106,8 +106,14 @@ class PurchaseOrderLine(models.Model):
 
     def _set_equipment_category(self):
         if not self.equipment_category_id:
-            category_model = self.env["maintenance.equipment.category"]
-            category = category_model.create(self._prepare_equipment_category_vals())
+            category_model = self.env["maintenance.equipment.category"].sudo()
+            category = fields.first(
+                self.product_id.product_tmpl_id.categ_id.equipment_category_ids
+            )
+            if not category:
+                category = category_model.create(
+                    self._prepare_equipment_category_vals()
+                )
             self.equipment_category_id = category.id
 
     def _prepare_equipment_vals(self):


### PR DESCRIPTION
This fixes a bug when you create equipments from a purchase/invoice with two lines, with products with the same category but it was not used before. Two identical categories would have been created.