### PR TITLE
[14.0][FIX] maintenance_account: Avoid error when post the invoice if the user does not have permissions to create maintenance records

### DIFF
--- a/maintenance_account/models/account_move.py
+++ b/maintenance_account/models/account_move.py
@@ -19,7 +19,8 @@ class AccountMove(models.Model):
 
     def action_post(self):
         super().action_post()
-        equipment_model = self.env["maintenance.equipment"]
+        # Prevent error if user does not have permission to create equipments
+        equipment_model = self.env["maintenance.equipment"].sudo()
         for move in self.filtered(lambda r: r.is_purchase_document()):
             for line in move.line_ids.filtered(
                 lambda x: (
@@ -35,7 +36,9 @@ class AccountMove(models.Model):
                 vals = line._prepare_equipment_vals()
                 equipment_ids = []
                 for _i in range(1, limit):
-                    equipment = equipment_model.create(vals)
+                    equipment = equipment_model.with_company(
+                        move.company_id,
+                    ).create(vals.copy())
                     equipment_ids.append((4, equipment.id))
                 line.equipment_ids = equipment_ids
 
@@ -97,8 +100,11 @@ class AccountMoveLine(models.Model):
 
     def _set_equipment_category(self):
         if not self.equipment_category_id:
-            category_model = self.env["maintenance.equipment.category"]
-            category = category_model.create(self._prepare_equipment_category_vals())
+            # Prevent error if user does not have permission to create equipments
+            category_model = self.env["maintenance.equipment.category"].sudo()
+            category = category_model.with_company(self.company_id).create(
+                self._prepare_equipment_category_vals()
+            )
             self.equipment_category_id = category.id
 
     def _prepare_equipment_vals(self):

--- a/maintenance_account/tests/test_maintenance_account.py
+++ b/maintenance_account/tests/test_maintenance_account.py
@@ -1,14 +1,27 @@
-# Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2022-2023 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo import fields
-from odoo.tests import Form, common
+from odoo.tests import Form, common, new_test_user
+from odoo.tests.common import users
 
 
 class TestAccountMove(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        ctx = {
+            "mail_create_nolog": True,
+            "mail_create_nosubscribe": True,
+            "mail_notrack": True,
+            "no_reset_password": True,
+        }
+        new_test_user(
+            cls.env,
+            login="test-account-user",
+            groups="account.group_account_invoice",
+            context=ctx,
+        )
         cls.categ = cls.env["product.category"].create({"name": "Test category"})
         cls.product_a = cls.env["product.product"].create(
             {"name": "Test product A", "maintenance_ok": True, "categ_id": cls.categ.id}
@@ -62,6 +75,7 @@ class TestAccountMove(common.SavepointCase):
         invoice = move_form.save()
         return invoice
 
+    @users("test-account-user")
     def test_invoice_out_invoice_action_post_equipment_1(self):
         invoice = self._create_invoice("out_invoice")
         line_a = invoice.line_ids.filtered(lambda x: x.product_id == self.product_a)
@@ -72,6 +86,7 @@ class TestAccountMove(common.SavepointCase):
         equipments = invoice.mapped("line_ids.equipment_ids")
         self.assertEqual(len(equipments), 0)
 
+    @users("test-account-user")
     def test_invoice_action_post_equipment_1(self):
         invoice = self._create_invoice()
         line_a = invoice.line_ids.filtered(lambda x: x.product_id == self.product_a)
@@ -93,9 +108,12 @@ class TestAccountMove(common.SavepointCase):
         self.assertEqual(equipment.partner_id, self.partner)
         self.assertEqual(equipment.partner_ref, invoice.ref)
 
+    @users("test-account-user")
     def test_invoice_action_post_equipment_2(self):
-        category = self.env["maintenance.equipment.category"].create(
-            {"name": self.categ.name, "product_category_id": self.categ.id}
+        category = (
+            self.env["maintenance.equipment.category"]
+            .sudo()
+            .create({"name": self.categ.name, "product_category_id": self.categ.id})
         )
         invoice = self._create_invoice()
         line_a = invoice.line_ids.filtered(lambda x: x.product_id == self.product_a)


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/maintenance/pull/310

Avoid error when post the invoice if the user does not have permissions to create maintenance records.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT41917