### PR TITLE
[13.0][IMP] maintenance_plan: Add rules to maintenance.plan to view records of the equipments they follow

### DIFF
--- a/maintenance_plan/security/maintenance_security.xml
+++ b/maintenance_plan/security/maintenance_security.xml
@@ -8,4 +8,20 @@
             name="domain_force"
         >['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
     </record>
+    <record id="maintenance_plan_rule_user" model="ir.rule">
+        <field
+            name="name"
+        >Users are allowed to access plan from equipments they follow</field>
+        <field name="model_id" ref="model_maintenance_plan" />
+        <field
+            name="domain_force"
+        >[('equipment_id.message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]" />
+    </record>
+    <record id="maintenance_plan_rule_admin_user" model="ir.rule">
+        <field name="name">Administrator of maintenance plans</field>
+        <field name="model_id" ref="model_maintenance_plan" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('maintenance.group_equipment_manager'))]" />
+    </record>
 </odoo>


### PR DESCRIPTION
Add rules to `maintenance.plan` to view records of the equipments they follow.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT42535