### PR TITLE
[15.0][FIX] maintenance_account: Add the field equipment_ids

### DIFF
--- a/maintenance_account/views/account_move_view.xml
+++ b/maintenance_account/views/account_move_view.xml
@@ -30,6 +30,7 @@
                     attrs="{'column_invisible': [('parent.move_type', '!=', 'in_invoice')]}"
                     optional="hide"
                 />
+                <field name="equipment_ids" invisible="1" />
             </xpath>
             <xpath
                 expr="//notebook//field[@name='line_ids']/tree/field[@name='date_maturity']"
@@ -40,6 +41,7 @@
                     domain="[('company_id','=', parent.company_id)]"
                     optional="hide"
                 />
+                <field name="equipment_ids" invisible="1" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
We want to add it in order to avoid that the information when using the purchase field.