### PR TITLE
[16.0][FIX] base_maintenance: style on ButtonBox and colspan

### DIFF
--- a/base_maintenance/views/maintenance_request_views.xml
+++ b/base_maintenance/views/maintenance_request_views.xml
@@ -9,16 +9,12 @@
         <field name="priority" eval="999" />
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_title')]" position="before">
-                <div
-                    class="oe_button_box"
-                    name="button_box"
-                    style="margin-right: 10px;"
-                >
+                <div class="oe_button_box" name="button_box">
                     <!--Empty, to be inherited by other modules.-->
                 </div>
             </xpath>
             <field name="description" position="replace">
-                <notebook colspan="4">
+                <notebook colspan="2">
                     <page name="description_page" string="Description">
                         <field name="description" />
                     </page>


### PR DESCRIPTION
Currently working on maintenance_timesheet migration and once I inherit the button_box the following error is thrown:
![image](https://github.com/OCA/maintenance/assets/69461150/545e2e11-3b80-47f1-85b1-daec36eb1c42)