### PR TITLE
[14.0][IMP] maintenance_plan: Create requests from a domain

### DIFF
--- a/maintenance_plan/models/maintenance_plan.py
+++ b/maintenance_plan/models/maintenance_plan.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import safe_eval
 
 
 class MaintenancePlan(models.Model):
@@ -81,6 +82,44 @@ class MaintenancePlan(models.Model):
     skip_notify_follower_on_requests = fields.Boolean(
         string="Do not notify to follower when creating requests?", default=True
     )
+    generate_with_domain = fields.Boolean()
+    generate_domain = fields.Char(string="Apply on")
+    search_equipment_id = fields.Many2one(
+        comodel_name="maintenance.equipment",
+        compute="_compute_search_equipment",
+        search="_search_search_equipment",
+    )
+
+    @api.model
+    def _search_search_equipment(self, operator, value):
+        if operator != "=" or not value:
+            raise ValueError(_("Unsupported search operator"))
+        plans = self.search([("generate_with_domain", "=", True)])
+        plan_ids = []
+        equipment = self.env["maintenance.equipment"].browse(value)
+        for plan in plans:
+            if equipment.filtered_domain(
+                safe_eval.safe_eval(
+                    plan.generate_domain or "[]", plan._get_eval_context()
+                )
+            ):
+                plan_ids.append(plan.id)
+        return ["|", ("equipment_id", "=", value), ("id", "in", plan_ids)]
+
+    @api.depends("equipment_id")
+    def _compute_search_equipment(self):
+        for record in self:
+            record.search_equipment_id = record.equipment_id
+
+    def _get_eval_context(self):
+        """Prepare the context used when evaluating python code
+        :returns: dict -- evaluation context given to safe_eval
+        """
+        return {
+            "datetime": safe_eval.datetime,
+            "dateutil": safe_eval.dateutil,
+            "time": safe_eval.time,
+        }
 
     def name_get(self):
         result = []
@@ -209,3 +248,13 @@ class MaintenancePlan(models.Model):
         for plan in self:
             equipment = plan.equipment_id
             equipment._create_new_request(plan)
+
+    def _get_maintenance_equipments(self):
+        self.ensure_one()
+        if self.generate_with_domain and not self.equipment_id:
+            return self.env["maintenance.equipment"].search(
+                safe_eval.safe_eval(
+                    self.generate_domain or "[]", self._get_eval_context()
+                )
+            )
+        return [self.equipment_id]

--- a/maintenance_plan/readme/USAGE.rst
+++ b/maintenance_plan/readme/USAGE.rst
@@ -22,3 +22,7 @@ planning horizon. Therefore, the maintenance manager can have a proper planning
 of how many maintenance requests are programming for the future. Leaving planning
 horizon to 0 will only create those maintenance request that are scheduled for
 today.
+
+We can also create maintenance requests from a plan using a domain for selecting the equipments.
+This way, we might have a single plan that will generate all the requests.
+In order to use it, we need to mark the `Generate with Domain` field.

--- a/maintenance_plan/tests/__init__.py
+++ b/maintenance_plan/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_maintenance_plan
+from . import test_maintenance_plan_domain

--- a/maintenance_plan/tests/common.py
+++ b/maintenance_plan/tests/common.py
@@ -65,4 +65,13 @@ class TestMaintenancePlanBase(test_common.SavepointCase):
                 "planning_step": "month",
             }
         )
+        cls.maintenance_plan_5 = cls.maintenance_plan_obj.create(
+            {
+                "start_maintenance_date": today,
+                "interval": 1,
+                "interval_step": "month",
+                "maintenance_plan_horizon": 2,
+                "planning_step": "month",
+            }
+        )
         cls.report_obj = cls.env["ir.actions.report"]

--- a/maintenance_plan/tests/test_maintenance_plan_domain.py
+++ b/maintenance_plan/tests/test_maintenance_plan_domain.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Dixmit
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import json
+
+from odoo.addons.maintenance_plan.tests.common import TestMaintenancePlanBase
+
+
+class TestMaintenancePlanDomain(TestMaintenancePlanBase):
+    def test_generate_requests_no_domain(self):
+        self.cron.method_direct_trigger()
+        generated_requests = self.maintenance_request_obj.search(
+            [("maintenance_plan_id", "=", self.maintenance_plan_5.id)],
+            order="schedule_date asc",
+        )
+
+        self.assertEqual(len(generated_requests), 3)
+        self.assertFalse(generated_requests.mapped("equipment_id"))
+
+    def test_generate_requests_domain(self):
+        equipment_2 = self.maintenance_equipment_obj.create({"name": "Laptop 2"})
+        self.maintenance_plan_5.write(
+            {
+                "generate_with_domain": True,
+                "generate_domain": json.dumps(
+                    [("id", "in", [equipment_2.id, self.equipment_1.id])]
+                ),
+            }
+        )
+        self.cron.method_direct_trigger()
+        generated_requests = self.maintenance_request_obj.search(
+            [("maintenance_plan_id", "=", self.maintenance_plan_5.id)],
+            order="schedule_date asc",
+        )
+
+        self.assertEqual(len(generated_requests), 6)
+        self.assertIn(equipment_2, generated_requests.mapped("equipment_id"))
+        self.assertIn(self.equipment_1, generated_requests.mapped("equipment_id"))

--- a/maintenance_plan/views/maintenance_equipment_views.xml
+++ b/maintenance_plan/views/maintenance_equipment_views.xml
@@ -15,7 +15,7 @@
                 >
                     <field
                         string="Plans"
-                        name="maintenance_plan_count"
+                        name="search_maintenance_plan_count"
                         widget="statinfo"
                     />
                 </button>

--- a/maintenance_plan/views/maintenance_plan_views.xml
+++ b/maintenance_plan/views/maintenance_plan_views.xml
@@ -67,6 +67,16 @@
                                 name="maintenance_team_id"
                                 attrs="{'required': [('equipment_id', '=', False)]}"
                             />
+                            <field
+                                name="generate_with_domain"
+                                attrs="{'invisible': [('equipment_id', '!=', False)]}"
+                            />
+                            <field
+                                name="generate_domain"
+                                widget="domain"
+                                options="{'model': 'maintenance.equipment', 'in_dialog': True}"
+                                attrs="{'invisible': ['|', ('equipment_id', '!=', False), ('generate_with_domain', '=', False)]}"
+                            />
                         </group>
                         <group>
                             <field name="skip_notify_follower_on_requests" />
@@ -181,7 +191,7 @@
             'default_equipment_id': active_id, 'hide_equipment_id': 0
         }</field>
         <field name="domain">['|', ('active', '=', True), ('active', '=',
-            False), ('equipment_id', '=', active_id)]
+            False), ('search_equipment_id', '=', active_id)]
         </field>
     </record>
     <menuitem


### PR DESCRIPTION
This PR Allows us to create several requests from a single plan using a domain to set several equipments.

For example, I create a plan for callibration of all the equipments for category Monitor. Then, at the specified time, for all the active monitors in my sistem, a callibration action will be generated.