### PR TITLE
[14.0][FIX] maintenance_plan: Use language on cron creation

### DIFF
--- a/maintenance_plan/models/maintenance_equipment.py
+++ b/maintenance_plan/models/maintenance_equipment.py
@@ -61,7 +61,11 @@ class MaintenanceEquipment(models.Model):
         if not team_id:
             team_id = request_model._get_default_team_id()
 
-        description = self.name if self else maintenance_plan.name
+        description = (
+            self.with_context(lang=self.env.user.lang).name
+            if self
+            else maintenance_plan.name
+        )
         kind = maintenance_plan.maintenance_kind_id.name or _("Unspecified kind")
         name = _("Preventive Maintenance (%s) - %s") % (kind, description)
 


### PR DESCRIPTION
Without this change, we might have problems when creating the request as data might differ from what you write (for example, if we come from a copied record).

Issued is raised because cron are executed with no lang.

The problems comes from using a field that is translatable