### PR TITLE
[15.0][IMP] maintenance_plan: Add freeze_time to prevent errors in tests

### DIFF
--- a/maintenance_plan/models/maintenance_plan.py
+++ b/maintenance_plan/models/maintenance_plan.py
@@ -123,7 +123,7 @@ class MaintenancePlan(models.Model):
     def _compute_next_maintenance(self):
         for plan in self.filtered(lambda x: x.interval > 0):
 
-            interval_timedelta = self.get_relativedelta(
+            interval_timedelta = plan.get_relativedelta(
                 plan.interval, plan.interval_step
             )
 


### PR DESCRIPTION
Add `freeze_time` to prevent errors in tests.

Please @pedrobaeza can you review it?

@Tecnativa