### PR TITLE
[FIX] maintenance_request_purchase: Do not copy fields

### DIFF
--- a/maintenance_request_purchase/models/maintenance_request.py
+++ b/maintenance_request_purchase/models/maintenance_request.py
@@ -15,6 +15,7 @@ class MaintenanceRequest(models.Model):
         "purchase_order_id",
         groups="purchase.group_purchase_user",
         string="Purchase Orders",
+        copy=False,
     )
     purchases_count = fields.Integer(
         compute="_compute_purchases_count",

--- a/maintenance_request_purchase/models/purchase_order.py
+++ b/maintenance_request_purchase/models/purchase_order.py
@@ -14,6 +14,7 @@ class PurchaseOrder(models.Model):
         "purchase_order_id",
         "maintenance_request_id",
         string="Maintenance Requests",
+        copy=False,
     )
 
     maintenance_requests_count = fields.Integer(


### PR DESCRIPTION
When copying a record, we should not store this data, at least it has no sense IMO :smile: 