### PR TITLE
[11.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/maintenance_plan/__manifest__.py
+++ b/maintenance_plan/__manifest__.py
@@ -3,7 +3,7 @@
 {'name': 'Maintenance Plan',
  'summary': 'Extends preventive maintenance planning',
  'version': '11.0.2.4.1',
- 'author': 'Camptocamp SA, Eficent, Odoo Community Association (OCA)',
+ 'author': 'Camptocamp, Eficent, Odoo Community Association (OCA)',
  'license': 'AGPL-3',
  'category': 'Maintenance',
  'website': 'https://github.com/OCA/maintenance',


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 11.0.