### PR TITLE
[10.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/maintenance_plan/__manifest__.py
+++ b/maintenance_plan/__manifest__.py
@@ -4,7 +4,7 @@
 {'name': 'Maintenance Plan',
  'summary': 'Extends preventive maintenance planning',
  'version': '10.0.1.0.0',
- 'author': 'Odoo Community Association (OCA), Camptocamp SA',
+ 'author': 'Odoo Community Association (OCA), Camptocamp',
  'license': 'AGPL-3',
  'category': 'Maintenance',
  'website': 'http://www.camptocamp.com',


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 10.0.