### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/maintenance_plan/__manifest__.py
+++ b/maintenance_plan/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Maintenance Plan",
     "summary": "Extends preventive maintenance planning",
     "version": "14.0.1.6.5",
-    "author": "Camptocamp SA, ForgeFlow, Odoo Community Association (OCA)",
+    "author": "Camptocamp, ForgeFlow, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Maintenance",
     "website": "https://github.com/OCA/maintenance",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.