### PR TITLE
[17.0][IMP] maintenance_project: Remove the Project > Administrator permission dependency

### DIFF
--- a/maintenance_project/README.rst
+++ b/maintenance_project/README.rst
@@ -31,8 +31,9 @@ Maintenance Projects
 This module extends the functionality of Odoo Maintenance module adding
 this features:
 
--  Adds a project to an equipment. The project can be automatically
-   created from the equipment definition.
+-  Adds a project to an equipment. You can link an existing project or
+   create a new one (with the Create project button) after creating the
+   equipment.
 -  Adds project and task to a maintenance request. The default project
    for a request will be the equipment one, including the preventive
    requests periodically created.

--- a/maintenance_project/__manifest__.py
+++ b/maintenance_project/__manifest__.py
@@ -3,14 +3,13 @@
 {
     "name": "Maintenance Projects",
     "summary": "Adds projects to maintenance equipments and requests",
-    "version": "17.0.1.0.0",
+    "version": "17.0.2.0.0",
     "author": "Odoo Community Association (OCA), Solvos",
     "license": "AGPL-3",
     "category": "Maintenance",
     "website": "https://github.com/OCA/maintenance",
     "depends": ["base_maintenance", "project"],
     "data": [
-        "security/maintenance_project_security.xml",
         "views/maintenance_equipment_views.xml",
         "views/maintenance_request_views.xml",
         "views/project_project_views.xml",

--- a/maintenance_project/demo/demo_maintenance_project.xml
+++ b/maintenance_project/demo/demo_maintenance_project.xml
@@ -21,7 +21,6 @@
         <field name="assign_date" eval="time.strftime('%Y-%m-10')" />
         <field name="serial_no">S/N 1</field>
         <field name="model">MODEL1</field>
-        <field name="create_project_from_equipment" eval="False" />
         <field name="project_id" ref="maintenance_project.project_project_1" />
     </record>
     <record id="equipment_2" model="maintenance.equipment">
@@ -36,7 +35,6 @@
         <field name="assign_date" eval="time.strftime('%Y-%m-10')" />
         <field name="serial_no">S/N 2</field>
         <field name="model">MODEL2</field>
-        <field name="create_project_from_equipment" eval="False" />
         <field name="project_id" ref="maintenance_project.project_project_1" />
         <field
             name="preventive_default_task_id"
@@ -51,6 +49,10 @@
         <field name="assign_date" eval="time.strftime('%Y-%m-10')" />
         <field name="serial_no">S/N 3</field>
         <field name="model">MODEL3</field>
-        <field name="create_project_from_equipment" eval="True" />
     </record>
+    <function
+        model="maintenance.equipment"
+        name="action_create_project"
+        eval="[[ref('equipment_3')]]"
+    />
 </odoo>

--- a/maintenance_project/migrations/17.0.2.0.0/post-migration.py
+++ b/maintenance_project/migrations/17.0.2.0.0/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2024 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env.ref("maintenance.group_equipment_manager").write(
+        {"implied_ids": [(3, env.ref("project.group_project_manager").id)]}
+    )

--- a/maintenance_project/models/maintenance_equipment.py
+++ b/maintenance_project/models/maintenance_equipment.py
@@ -1,31 +1,27 @@
 # Copyright 2019 Solvos Consultoría Informática (<http://www.solvos.es>)
+# Copyright 2024 Tecnativa - Víctor Martínez
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class MaintenanceEquipment(models.Model):
     _inherit = "maintenance.equipment"
 
     project_id = fields.Many2one(comodel_name="project.project", ondelete="restrict")
-    create_project_from_equipment = fields.Boolean(default=True)
     preventive_default_task_id = fields.Many2one(
         string="Default Task", comodel_name="project.task"
     )
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        project_obj = self.env["project.project"]
-        for values in vals_list:
-            if values.get("create_project_from_equipment"):
-                new_project = project_obj.create(
-                    self._prepare_project_from_equipment_values(values)
-                )
-                values["project_id"] = new_project.id
-        return super().create(vals_list)
+    def action_create_project(self):
+        self.ensure_one()
+        if not self.project_id:
+            self.project_id = self.env["project.project"].create(
+                self._prepare_project_from_equipment_values()
+            )
 
-    def _prepare_project_from_equipment_values(self, values):
+    def _prepare_project_from_equipment_values(self):
         """
         Default project data creation hook
         """
-        return {"name": values.get("name")}
+        return {"name": self.name}

--- a/maintenance_project/readme/DESCRIPTION.md
+++ b/maintenance_project/readme/DESCRIPTION.md
@@ -1,8 +1,9 @@
 This module extends the functionality of Odoo Maintenance module adding
 this features:
 
-- Adds a project to an equipment. The project can be automatically
-  created from the equipment definition.
+- Adds a project to an equipment. You can link an existing project or
+  create a new one (with the Create project button) after creating the
+  equipment.
 - Adds project and task to a maintenance request. The default project
   for a request will be the equipment one, including the preventive
   requests periodically created.

--- a/maintenance_project/security/maintenance_project_security.xml
+++ b/maintenance_project/security/maintenance_project_security.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<odoo>
-    <record id="maintenance.group_equipment_manager" model="res.groups">
-        <field name="implied_ids" eval="[(4, ref('project.group_project_manager'))]" />
-    </record>
-</odoo>

--- a/maintenance_project/static/description/index.html
+++ b/maintenance_project/static/description/index.html
@@ -372,8 +372,9 @@ ul.auto-toc {
 <p>This module extends the functionality of Odoo Maintenance module adding
 this features:</p>
 <ul class="simple">
-<li>Adds a project to an equipment. The project can be automatically
-created from the equipment definition.</li>
+<li>Adds a project to an equipment. You can link an existing project or
+create a new one (with the Create project button) after creating the
+equipment.</li>
 <li>Adds project and task to a maintenance request. The default project
 for a request will be the equipment one, including the preventive
 requests periodically created.</li>

--- a/maintenance_project/static/description/index.html
+++ b/maintenance_project/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -418,9 +417,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/maintenance_project/tests/test_maintenance_project.py
+++ b/maintenance_project/tests/test_maintenance_project.py
@@ -1,21 +1,30 @@
 # Copyright 2019 Solvos Consultor??a Inform??tica (<http://www.solvos.es>)
+# Copyright 2024 Tecnativa - Víctor Martínez
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-import odoo.tests.common as test_common
+from odoo.tests import Form, new_test_user
+from odoo.tests.common import users
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestMaintenanceProject(test_common.TransactionCase):
+class TestMaintenanceProject(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
         cls.project1 = cls.env["project.project"].create({"name": "My project"})
-        cls.project_demo1 = cls.env.ref("maintenance_project.project_project_1")
-
+        cls.project_demo = cls.env.ref("maintenance_project.project_project_1")
+        new_test_user(
+            cls.env, login="test-user", groups="maintenance.group_equipment_manager"
+        )
+        new_test_user(
+            cls.env,
+            login="test-project_manager-user",
+            groups="maintenance.group_equipment_manager,project.group_project_manager",
+        )
         cls.equipment1 = cls.env["maintenance.equipment"].create(
             {
                 "name": "My equipment",
-                "create_project_from_equipment": True,
                 "maintenance_team_id": cls.env.ref(
                     "maintenance.equipment_team_metrology"
                 ).id,
@@ -24,46 +33,61 @@ class TestMaintenanceProject(test_common.TransactionCase):
         cls.equipment2 = cls.env["maintenance.equipment"].create(
             {
                 "name": "My equipment without project",
-                "create_project_from_equipment": False,
             }
         )
         cls.equipment3 = cls.env["maintenance.equipment"].create(
             {
                 "name": "My equipment with related project",
-                "create_project_from_equipment": False,
                 "project_id": cls.project1.id,
             }
         )
+        cls.equipment_demo = cls.env.ref("maintenance_project.equipment_3")
 
-        cls.equipment_demo1 = cls.env.ref("maintenance_project.equipment_1")
-        cls.equipment_demo2 = cls.env.ref("maintenance_project.equipment_2")
-        cls.equipment_demo3 = cls.env.ref("maintenance_project.equipment_3")
-
-    def test_maintenance_equipment_project(self):
-        self.assertEqual(self.equipment1.name, self.equipment1.project_id.name)
+    def test_maintenance_equipment_project_misc(self):
+        self.assertFalse(self.equipment1.project_id)
         self.assertFalse(self.equipment2.project_id)
         self.assertEqual(self.equipment3.project_id, self.project1)
-        self.assertEqual(
-            self.equipment_demo3.name, self.equipment_demo3.project_id.name
+        self.assertEqual(self.equipment_demo.name, self.equipment_demo.project_id.name)
+
+    @users("test-project_manager-user")
+    def test_maintenance_equipment_project_admin(self):
+        equipment_a = self.env["maintenance.equipment"].create(
+            {
+                "name": "Test equipment A",
+            }
         )
+        self.assertFalse(equipment_a.project_id)
+        equipment_a.action_create_project()
+        self.assertTrue(equipment_a.project_id)
+        self.assertEqual(equipment_a.name, equipment_a.project_id.name)
+        equipment_b = self.env["maintenance.equipment"].create(
+            {
+                "name": "Test equipment b",
+                "project_id": self.project1.id,
+            }
+        )
+        self.assertEqual(equipment_b.project_id, self.project1)
+        equipment_b.action_create_project()
+        self.assertEqual(equipment_b.project_id, self.project1)
 
     def test_project_equipment_count(self):
+        self.equipment1.action_create_project()
         self.assertEqual(self.project1.equipment_count, 1)
         self.assertEqual(self.equipment1.project_id.equipment_count, 1)
-        self.assertEqual(self.project_demo1.equipment_count, 2)
-        self.assertEqual(self.equipment_demo3.project_id.equipment_count, 1)
+        self.assertEqual(self.project_demo.equipment_count, 2)
+        self.assertEqual(self.equipment_demo.project_id.equipment_count, 1)
 
-    def test_request_onchange_equipment(self):
-        req1 = self.env["maintenance.request"].new({"name": "My test request #1"})
-        self.assertFalse(req1.project_id)
-        req1.equipment_id = self.equipment1
-        req1.onchange_equipment_id()
-        self.assertEqual(req1.project_id, self.equipment1.project_id)
-
-        req2 = self.env["maintenance.request"].new({"name": "My test request #2"})
-        req2.equipment_id = self.equipment2
-        req2.onchange_equipment_id()
-        self.assertFalse(req2.project_id)
+    @users("test-user")
+    def test_request_equipment(self):
+        request_form_1 = Form(self.env["maintenance.request"])
+        request_form_1.name = "My test request #1"
+        self.assertFalse(request_form_1.project_id)
+        request_form_1.equipment_id = self.equipment1
+        self.assertEqual(request_form_1.project_id, self.equipment1.project_id)
+        request_form_2 = Form(self.env["maintenance.request"])
+        request_form_2.name = "My test request #2"
+        request_form_2.equipment_id = self.equipment2
+        self.assertFalse(request_form_2.project_id)
 
     def test_generate_requests(self):
         req_name = "My new recurring test request"
@@ -95,12 +119,11 @@ class TestMaintenanceProject(test_common.TransactionCase):
         my_requests = request_obj.search(domain)
         self.assertEqual(len(my_requests), 2)
 
-    def test_action_views(self):
+    def test_project_action_views(self):
         act1 = self.project1.action_view_equipment_ids()
         self.assertEqual(act1["domain"][0][2], self.project1.id)
         self.assertEqual(act1["context"]["default_project_id"], self.project1.id)
         self.assertFalse(act1["context"]["default_create_project_from_equipment"])
-
         act2 = self.project1.action_view_maintenance_request_ids()
         self.assertEqual(act2["domain"][0][2], self.project1.id)
         self.assertEqual(act2["context"]["default_project_id"], self.project1.id)

--- a/maintenance_project/tests/test_maintenance_project.py
+++ b/maintenance_project/tests/test_maintenance_project.py
@@ -15,7 +15,9 @@ class TestMaintenanceProject(BaseCommon):
         cls.project1 = cls.env["project.project"].create({"name": "My project"})
         cls.project_demo = cls.env.ref("maintenance_project.project_project_1")
         new_test_user(
-            cls.env, login="test-user", groups="maintenance.group_equipment_manager"
+            cls.env,
+            login="test-user",
+            groups="maintenance.group_equipment_manager,project.group_project_user",
         )
         new_test_user(
             cls.env,

--- a/maintenance_project/views/maintenance_equipment_views.xml
+++ b/maintenance_project/views/maintenance_equipment_views.xml
@@ -37,11 +37,24 @@
         <field name="inherit_id" ref="maintenance.hr_equipment_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='location']" position="after">
-                <field name="create_project_from_equipment" invisible="id" />
-                <field
-                    name="project_id"
-                    invisible="create_project_from_equipment and not id"
-                />
+                <field name="project_id" invisible="1" />
+                <label for="project_id" />
+                <div>
+                    <field
+                        name="project_id"
+                        groups="project.group_project_manager"
+                        class="oe_inline"
+                    />
+                    <button
+                        name="action_create_project"
+                        groups="project.group_project_manager"
+                        type="object"
+                        class="oe_link"
+                        invisible="not id or project_id"
+                    >
+                        <span class="fa fa-plus" /><span> Create project</span>
+                    </button>
+                </div>
             </xpath>
             <xpath expr="//group[@name='statistics']" position="after">
                 <group name="project_task">

--- a/maintenance_project/views/maintenance_equipment_views.xml
+++ b/maintenance_project/views/maintenance_equipment_views.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="maintenance.hr_equipment_view_search" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='owner_user_id']" position="after">
-                <field name="project_id" />
+                <field name="project_id" groups="project.group_project_user" />
             </xpath>
         </field>
     </record>
@@ -14,7 +14,7 @@
         <field name="inherit_id" ref="maintenance.hr_equipment_view_tree" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='category_id']" position="after">
-                <field name="project_id" />
+                <field name="project_id" groups="project.group_project_user" />
             </xpath>
         </field>
     </record>
@@ -23,10 +23,13 @@
         <field name="inherit_id" ref="maintenance.hr_equipment_view_kanban" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='activity_state']" position="after">
-                <field name="project_id" />
+                <field name="project_id" groups="project.group_project_user" />
             </xpath>
             <xpath expr="//div[hasclass('o_kanban_record_body')]" position="inside">
-                <div t-if="record.project_id.raw_value">
+                <div
+                    t-if="record.project_id.raw_value"
+                    groups="project.group_project_user"
+                >
                     <small>Project: <t t-out="record.project_id.value" /></small>
                 </div>
             </xpath>
@@ -38,11 +41,11 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='location']" position="after">
                 <field name="project_id" invisible="1" />
-                <label for="project_id" />
+                <label for="project_id" groups="project.group_project_user" />
                 <div>
                     <field
                         name="project_id"
-                        groups="project.group_project_manager"
+                        groups="project.group_project_user"
                         class="oe_inline"
                     />
                     <button
@@ -62,6 +65,7 @@
                         name="preventive_default_task_id"
                         domain="[('project_id', '=', project_id)]"
                         context="{'default_project_id': project_id}"
+                        groups="project.group_project_user"
                     />
                 </group>
             </xpath>

--- a/maintenance_project/views/maintenance_request_views.xml
+++ b/maintenance_project/views/maintenance_request_views.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="maintenance.hr_equipment_request_view_search" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='maintenance_team_id']" position="after">
-                <field name="project_id" />
+                <field name="project_id" groups="project.group_project_user" />
             </xpath>
         </field>
     </record>
@@ -14,7 +14,7 @@
         <field name="inherit_id" ref="maintenance.hr_equipment_request_view_tree" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='category_id']" position="after">
-                <field name="project_id" />
+                <field name="project_id" groups="project.group_project_user" />
             </xpath>
         </field>
     </record>
@@ -23,10 +23,13 @@
         <field name="inherit_id" ref="maintenance.hr_equipment_request_view_kanban" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='activity_state']" position="after">
-                <field name="project_id" />
+                <field name="project_id" groups="project.group_project_user" />
             </xpath>
             <xpath expr="//div[hasclass('o_kanban_record_body')]" position="inside">
-                <div t-if="record.project_id.raw_value">
+                <div
+                    t-if="record.project_id.raw_value"
+                    groups="project.group_project_user"
+                >
                     <small>Project: <t t-out="record.project_id.value" /></small>
                 </div>
             </xpath>
@@ -37,11 +40,14 @@
         <field name="inherit_id" ref="maintenance.hr_equipment_request_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='priority']" position="after">
-                <field name="project_id" />
+                <field name="project_id" invisible="1" />
+                <field name="project_id" groups="project.group_project_user" />
+                <field name="task_id" invisible="1" />
                 <field
                     name="task_id"
                     domain="[('project_id', '=', project_id)]"
                     context="{'default_project_id': project_id}"
+                    groups="project.group_project_user"
                 />
             </xpath>
         </field>

--- a/maintenance_project/views/project_project_views.xml
+++ b/maintenance_project/views/project_project_views.xml
@@ -5,14 +5,21 @@
         <field name="inherit_id" ref="project.view_project_kanban" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='rating_status']" position="after">
-                <field name="equipment_count" />
-                <field name="maintenance_request_count" />
+                <field
+                    name="equipment_count"
+                    groups="maintenance.group_equipment_manager"
+                />
+                <field
+                    name="maintenance_request_count"
+                    groups="maintenance.group_equipment_manager"
+                />
             </xpath>
             <xpath expr="//div[hasclass('o_project_kanban_boxes')]" position="inside">
                 <a
                     class="o_project_kanban_box"
                     name="action_view_equipment_ids"
                     type="object"
+                    groups="maintenance.group_equipment_manager"
                 >
                     <div>
                         <span class="o_value">
@@ -25,6 +32,7 @@
                     class="o_project_kanban_box"
                     name="action_view_maintenance_request_ids"
                     type="object"
+                    groups="maintenance.group_equipment_manager"
                 >
                     <div>
                         <span class="o_value">
@@ -46,6 +54,7 @@
                     name="action_view_equipment_ids"
                     type="object"
                     icon="fa-ticket"
+                    groups="maintenance.group_equipment_manager"
                 >
                     <field
                         string="Equipments"
@@ -58,6 +67,7 @@
                     name="action_view_maintenance_request_ids"
                     type="object"
                     icon="fa-tasks"
+                    groups="maintenance.group_equipment_manager"
                 >
                     <field
                         string="Requests"

--- a/maintenance_timesheet/models/maintenance_equipment.py
+++ b/maintenance_timesheet/models/maintenance_equipment.py
@@ -7,7 +7,7 @@ from odoo import models
 class MaintenanceEquipment(models.Model):
     _inherit = "maintenance.equipment"
 
-    def _prepare_project_from_equipment_values(self, values):
-        data = super()._prepare_project_from_equipment_values(values)
+    def _prepare_project_from_equipment_values(self):
+        data = super()._prepare_project_from_equipment_values()
         data["allow_timesheets"] = True
         return data

--- a/maintenance_timesheet/tests/test_maintenance_timesheet.py
+++ b/maintenance_timesheet/tests/test_maintenance_timesheet.py
@@ -102,7 +102,6 @@ class TestMaintenanceTimesheet(TransactionCase):
         self.assertFalse(act1["context"]["readonly_employee_id"])
 
     def test_prepare_project_from_equipment_values(self):
-        data = self.env["maintenance.equipment"]._prepare_project_from_equipment_values(
-            {"name": "my name"}
-        )
-        self.assertTrue(data["allow_timesheets"])
+        equipment = self.env["maintenance.equipment"].create({"name": "Test equipment"})
+        equipment.action_create_project()
+        self.assertTrue(equipment.project_id.allow_timesheets)


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/maintenance/pull/424

Changes done:
- [x] Remove the Project > Administrator permission dependency
- [x] Change `create_project_from_equipment` fields from equipments to '_Create project_' button
- [x] Add `groups="project.group_project_user"` to project/task fields
- [x] Add `groups="maintenance.group_equipment_manager"` to maintenance fields

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT50829