### PR TITLE
[16.0][FIX] maintenance_request_sequence: add create_multi

### DIFF
--- a/maintenance_request_sequence/models/maintenance_request.py
+++ b/maintenance_request_sequence/models/maintenance_request.py
@@ -11,14 +11,15 @@ class MaintenanceRequest(models.Model):
 
     code = fields.Char(readonly=True, copy=False, default="/")
 
-    @api.model
-    def create(self, vals):
-        if vals.get("code", "/") == "/":
-            team_id = vals.get("maintenance_team_id")
-            sequence = self.env["maintenance.team"].browse(
-                team_id
-            ).sequence_id or self.env.ref(
-                "maintenance_request_sequence.seq_maintenance_request_auto"
-            )
-            vals["code"] = sequence.next_by_id()
-        return super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("code", "/") == "/":
+                team_id = vals.get("maintenance_team_id")
+                sequence = self.env["maintenance.team"].browse(
+                    team_id
+                ).sequence_id or self.env.ref(
+                    "maintenance_request_sequence.seq_maintenance_request_auto"
+                )
+                vals["code"] = sequence.next_by_id()
+        return super().create(vals_list)

--- a/maintenance_request_sequence/models/maintenance_team.py
+++ b/maintenance_request_sequence/models/maintenance_team.py
@@ -47,11 +47,12 @@ class MaintenanceTeam(models.Model):
                     rec.sequence_id = self.env["ir.sequence"].create(seq_vals)
         return super().write(vals)
 
-    @api.model
-    def create(self, vals):
-        prefix = vals.get("code_prefix")
-        if prefix:
-            seq_vals = self._prepare_ir_sequence(prefix)
-            sequence = self.env["ir.sequence"].create(seq_vals)
-            vals["sequence_id"] = sequence.id
-        return super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            prefix = vals.get("code_prefix")
+            if prefix:
+                seq_vals = self._prepare_ir_sequence(prefix)
+                sequence = self.env["ir.sequence"].create(seq_vals)
+                vals["sequence_id"] = sequence.id
+        return super().create(vals_list)


### PR DESCRIPTION
Enable batch creation of records by applying the @model_create_multi decorator, improving performance when creating multiple records at once.