### PR TITLE
[17.0][FIX] maintenance_plan: Use 'active_id' instead of 'id' in action to fix error

### DIFF
--- a/maintenance_plan/views/maintenance_plan_views.xml
+++ b/maintenance_plan/views/maintenance_plan_views.xml
@@ -6,9 +6,9 @@
         <field name="binding_model_id" ref="model_maintenance_plan" />
         <field name="view_mode">kanban,tree,form,pivot,graph,calendar</field>
         <field name="context">{
-            'default_maintenance_plan_id': id,
+            'default_maintenance_plan_id': active_id,
         }</field>
-        <field name="domain">[('maintenance_plan_id', '=', id)]</field>
+        <field name="domain">[('maintenance_plan_id', '=', active_id)]</field>
     </record>
     <record id="maintenance_plan_view_form" model="ir.ui.view">
         <field name="name">maintenance.plan.form</field>


### PR DESCRIPTION
The action 'hr_equipment_request_action_from_plan' failed because 'id' was not found. Replaced 'id' with 'active_id' to ensure the correct context value is used.

cc https://github.com/APSL 164938

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review