### PR TITLE
[17.0][IMP] base_maintenance: Fine-tuning of the form view

### DIFF
--- a/base_maintenance/views/maintenance_request_views.xml
+++ b/base_maintenance/views/maintenance_request_views.xml
@@ -13,13 +13,9 @@
                     <!--Empty, to be inherited by other modules.-->
                 </div>
             </xpath>
-            <field name="description" position="replace">
-                <notebook colspan="2">
-                    <page name="description_page" string="Description">
-                        <field name="description" />
-                    </page>
-                </notebook>
-            </field>
+            <xpath expr="//field[@name='description']/.." position="attributes">
+                <attribute name="name">description_page</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/maintenance_plan/views/maintenance_equipment_views.xml
+++ b/maintenance_plan/views/maintenance_equipment_views.xml
@@ -83,12 +83,6 @@
                     />
                     </page>
             </xpath>
-            <xpath
-                expr="//notebook/page[@name='description_page']"
-                position="attributes"
-            >
-                    <attribute name="string">Notes</attribute>
-            </xpath>
         </field>
     </record>
     <record id="maintenance.hr_equipment_action" model="ir.actions.act_window">


### PR DESCRIPTION
With this commit https://github.com/odoo/odoo/commit/3bd841086d92246e55771785bcb69501af712ab6 the maintenance request form view now has an independent page. This commit adapts the view to align with the new page structure.

Before
![image](https://github.com/user-attachments/assets/2408ba7e-51cd-4346-820a-d3efa48cf1b0)

After
![image](https://github.com/user-attachments/assets/ff0b5ee1-2510-4a4a-b08e-b7b4e35cb094)


@Tecnativa @pedrobaeza @victoralmau could you please review this