### PR TITLE
[13.0][ADD] maintenance_request_purchase_order_type

### DIFF
--- a/maintenance_request_purchase_order_type/__init__.py
+++ b/maintenance_request_purchase_order_type/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/maintenance_request_purchase_order_type/__manifest__.py
+++ b/maintenance_request_purchase_order_type/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "Maintenance Request Purchase",
+    "summary": """
+        Link PO with maintenance requests - Order Type configuration""",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "Odoo Community Association (OCA), Solvos",
+    "website": "https://github.com/OCA/maintenance",
+    "depends": ["maintenance_request_purchase", "purchase_order_type"],
+    "data": [
+        "views/maintenance_request_views.xml",
+        "views/purchase_order_type_views.xml",
+    ],
+}

--- a/maintenance_request_purchase_order_type/models/__init__.py
+++ b/maintenance_request_purchase_order_type/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order_type

--- a/maintenance_request_purchase_order_type/models/purchase_order_type.py
+++ b/maintenance_request_purchase_order_type/models/purchase_order_type.py
@@ -1,0 +1,12 @@
+# Copyright 2025 Solvos Consultoría Informática (<http://www.solvos.es>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import fields, models
+
+
+class PurchaseOrderType(models.Model):
+    _inherit = "purchase.order.type"
+
+    use_maintenance_request = fields.Boolean(
+        string="Use in Maintenance Requests", default=False
+    )

--- a/maintenance_request_purchase_order_type/readme/CONTRIBUTORS.rst
+++ b/maintenance_request_purchase_order_type/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* David Alonso <david.alonso@solvos.es>

--- a/maintenance_request_purchase_order_type/readme/DESCRIPTION.rst
+++ b/maintenance_request_purchase_order_type/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module enables only those Purchase Orders for selected Order Types to be
+linked to Maintenance Requests.
+
+This could be useful in order to isolate whose POs that should be used with
+Maintenance Requests.

--- a/maintenance_request_purchase_order_type/views/maintenance_request_views.xml
+++ b/maintenance_request_purchase_order_type/views/maintenance_request_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="hr_equipment_request_view_form_button_box">
+        <field
+            name="name"
+        >maintenance.request.form (in maintenance_request_purchase_order_type)</field>
+        <field name="model">maintenance.request</field>
+        <field
+            name="inherit_id"
+            ref="maintenance_request_purchase.hr_equipment_request_view_form_button_box"
+        />
+        <field name="arch" type="xml">
+            <field name="purchase_order_ids" position="attributes">
+                <attribute
+                    name="domain"
+                >[('order_type.use_maintenance_request', '=', True)]</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/maintenance_request_purchase_order_type/views/purchase_order_type_views.xml
+++ b/maintenance_request_purchase_order_type/views/purchase_order_type_views.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="view_purchase_order_type_form">
+        <field
+            name="name"
+        >purchase.order.type.form (in maintenance_request_purchase_order_type)</field>
+        <field name="model">purchase.order.type</field>
+        <field
+            name="inherit_id"
+            ref="purchase_order_type.view_purchase_order_type_form"
+        />
+        <field name="arch" type="xml">
+            <field name="incoterm_id" position="after">
+                <field name="use_maintenance_request" widget="boolean_toggle" />
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_purchase_order_type_tree">
+        <field
+            name="name"
+        >purchase.order.type.tree (in maintenance_request_purchase_order_type)</field>
+        <field name="model">purchase.order.type</field>
+        <field
+            name="inherit_id"
+            ref="purchase_order_type.view_purchase_order_type_tree"
+        />
+        <field name="arch" type="xml">
+            <field name="incoterm_id" position="after">
+                <field
+                    name="use_maintenance_request"
+                    widget="boolean_toggle"
+                    optional="show"
+                    string="Use in Mt. Req."
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,2 +1,3 @@
 contract
+purchase-workflow
 server-tools

--- a/setup/maintenance_request_purchase_order_type/odoo/addons/maintenance_request_purchase_order_type
+++ b/setup/maintenance_request_purchase_order_type/odoo/addons/maintenance_request_purchase_order_type
@@ -1,0 +1,1 @@
+../../../../maintenance_request_purchase_order_type

--- a/setup/maintenance_request_purchase_order_type/setup.py
+++ b/setup/maintenance_request_purchase_order_type/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module enables only those Purchase Orders for selected Order Types to be linked to Maintenance Requests.

This could be useful in order to isolate whose POs that should be used with Maintenance Requests.