### PR TITLE
[IMP] maintenance_request_purchase: Allow to open the form of related Purchase Orders

### DIFF
--- a/maintenance_request_purchase/views/maintenance_request.xml
+++ b/maintenance_request_purchase/views/maintenance_request.xml
@@ -15,7 +15,10 @@
                     string="Purchase Orders"
                     groups="purchase.group_purchase_user"
                 >
-                    <field name="purchase_order_ids" />
+                    <field
+                        name="purchase_order_ids"
+                        context="{'tree_view_ref': 'maintenance_request_purchase.purchase_order_tree'}"
+                    />
                 </page>
             </notebook>
         </field>

--- a/maintenance_request_purchase/views/purchase_order_views.xml
+++ b/maintenance_request_purchase/views/purchase_order_views.xml
@@ -28,4 +28,24 @@
             </div>
         </field>
     </record>
+
+
+    <record model="ir.ui.view" id="purchase_order_tree">
+        <field name="name">purchase.order.form (in maintenance_purchase)</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_tree" />
+        <field name="priority" eval="99" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <tree position="inside">
+                <button
+                    name="get_formview_action"
+                    string="Open"
+                    type="object"
+                    class="btn btn-primary"
+                />
+            </tree>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
With this change, we can open the form of the PO. 

It is interesting if we have attachments and messages on the PO (not viewed otherwise)

![image](https://github.com/user-attachments/assets/9d9c80c4-f666-487f-824a-0ec331739c24)
