### PR TITLE
[17.0][FIX] maintenance_equipment_hierarchy: complete name crashes for new childs

### DIFF
--- a/maintenance_equipment_hierarchy/models/maintenance_equipment.py
+++ b/maintenance_equipment_hierarchy/models/maintenance_equipment.py
@@ -48,7 +48,7 @@ class MaintenanceEquipment(models.Model):
         for equipment in self:
             if equipment.parent_id:
                 parent_name = equipment.parent_id.complete_name
-                equipment.complete_name = parent_name + " / " + equipment.name
+                equipment.complete_name = parent_name + " / " + (equipment.name or "")
             else:
                 equipment.complete_name = equipment.name
 


### PR DESCRIPTION
Before this fix, when we're trying to create a child equipment from child equipments list view for a certain equipment, an error was raised. This fixes it.

Solves https://github.com/OCA/maintenance/issues/494