### PR TITLE
[16.0][IMP] maintenance_security: do not grant HR maintenance groups

### DIFF
--- a/maintenance_security/README.rst
+++ b/maintenance_security/README.rst
@@ -33,6 +33,8 @@ This module limits the Maintenance menu to users with any of the maintenance gro
 It also removes the assignation mail when a user with no permission is assigned to an
 equipment, as if not, the mail will contain a link to it.
 
+Additionally, it will remove the inheritance of equipment manager maintenance group by HR users (hr.group_hr_user) to further decouple the modules. The group can still be manually assigned to the user.
+
 **Table of contents**
 
 .. contents::

--- a/maintenance_security/readme/DESCRIPTION.rst
+++ b/maintenance_security/readme/DESCRIPTION.rst
@@ -2,3 +2,5 @@ This module limits the Maintenance menu to users with any of the maintenance gro
 
 It also removes the assignation mail when a user with no permission is assigned to an
 equipment, as if not, the mail will contain a link to it.
+
+Additionally, it will remove the inheritance of equipment manager maintenance group by HR users (hr.group_hr_user) to further decouple the modules. The group can still be manually assigned to the user.

--- a/maintenance_security/static/description/index.html
+++ b/maintenance_security/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -373,6 +373,7 @@ ul.auto-toc {
 <p>This module limits the Maintenance menu to users with any of the maintenance groups.</p>
 <p>It also removes the assignation mail when a user with no permission is assigned to an
 equipment, as if not, the mail will contain a link to it.</p>
+<p>Additionally, it will remove the inheritance of equipment manager maintenance group by HR users (hr.group_hr_user) to further decouple the modules. The group can still be manually assigned to the user.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -415,7 +416,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/maintenance_security/views/maintenance_views.xml
+++ b/maintenance_security/views/maintenance_views.xml
@@ -55,4 +55,12 @@
             eval="[(6, 0, [ref('maintenance.group_equipment_manager')])]"
         />
     </record>
+
+    <!-- HR officers and HR managers are NOT allowed to manage equipment automatically anymore -->
+    <record id="hr.group_hr_user" model="res.groups">
+        <field
+            name="implied_ids"
+            eval="[(3, ref('maintenance.group_equipment_manager'))]"
+        />
+    </record>
 </odoo>


### PR DESCRIPTION
Odoo grants HR users maintenance permissions by default on hr_maintenance

No need or requirement to do this automatically... because equipments could be not related to HR at all.

Better to use roles for this purpose.