### PR TITLE
[17.0][FIX] maintenance_timesheet: Define the correct rule to show only what is related to maintenance_request_id

### DIFF
--- a/maintenance_timesheet/README.rst
+++ b/maintenance_timesheet/README.rst
@@ -56,9 +56,9 @@ Authors
 Contributors
 ------------
 
-- David Alonso <david.alonso@solvos.es>
-- Luisa Miguéns <luisa.miguens@solvos.es>
-- Christian Ramos <c.ramos@binhex.es>
+-  David Alonso <david.alonso@solvos.es>
+-  Luisa Miguéns <luisa.miguens@solvos.es>
+-  Christian Ramos <c.ramos@binhex.es>
 
 Maintainers
 -----------

--- a/maintenance_timesheet/__manifest__.py
+++ b/maintenance_timesheet/__manifest__.py
@@ -5,7 +5,7 @@
     "summary": "Adds timesheets to maintenance requests",
     "author": "Odoo Community Association (OCA), Solvos",
     "license": "AGPL-3",
-    "version": "17.0.1.0.1",
+    "version": "17.0.1.1.0",
     "category": "Human Resources",
     "website": "https://github.com/OCA/maintenance",
     "depends": ["maintenance_project", "hr_timesheet"],

--- a/maintenance_timesheet/migrations/17.0.1.1.0/noupdate_changes.xml
+++ b/maintenance_timesheet/migrations/17.0.1.1.0/noupdate_changes.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="hr_timesheet_rule_request_user" model="ir.rule">
+        <field name="domain_force">[
+            ('maintenance_request_id.message_partner_ids', 'in', [user.partner_id.id]),
+            ('maintenance_request_id.user_id.id', '=', user.id)
+        ]
+        </field>
+    </record>
+</odoo>

--- a/maintenance_timesheet/migrations/17.0.1.1.0/post-migration.py
+++ b/maintenance_timesheet/migrations/17.0.1.1.0/post-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2025 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, "maintenance_timesheet", "17.0.1.1.0/noupdate_changes.xml"
+    )

--- a/maintenance_timesheet/security/maintenance_timesheet_security.xml
+++ b/maintenance_timesheet/security/maintenance_timesheet_security.xml
@@ -6,11 +6,8 @@
         >Users are allowed to access timesheets related to a followed request</field>
         <field name="model_id" ref="model_account_analytic_line" />
         <field name="domain_force">[
-                '|',
-                    ('maintenance_request_id', '=', False),
-                        '|',
-                            ('maintenance_request_id.message_partner_ids', 'in', [user.partner_id.id]),
-                            ('maintenance_request_id.user_id.id', '=', user.id)
+                ('maintenance_request_id.message_partner_ids', 'in', [user.partner_id.id]),
+                ('maintenance_request_id.user_id.id', '=', user.id)
             ]
         </field>
         <field


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/maintenance/pull/501

Define the correct rule to show only what is related to `maintenance_request_id`

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT56859