### PR TITLE
[15.0][FIX] maintenance_timesheet: Define the correct rule to show only what is related to maintenance_request_id

### DIFF
--- a/maintenance_timesheet/__manifest__.py
+++ b/maintenance_timesheet/__manifest__.py
@@ -5,7 +5,7 @@
     "summary": "Adds timesheets to maintenance requests",
     "author": "Odoo Community Association (OCA), Solvos",
     "license": "AGPL-3",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.1.0",
     "category": "Human Resources",
     "website": "https://github.com/OCA/maintenance",
     "depends": ["base_maintenance", "maintenance_project", "hr_timesheet"],

--- a/maintenance_timesheet/migrations/15.0.1.1.0/noupdate_changes.xml
+++ b/maintenance_timesheet/migrations/15.0.1.1.0/noupdate_changes.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="hr_timesheet_rule_request_user" model="ir.rule">
+        <field name="domain_force">[
+            ('maintenance_request_id.message_partner_ids', 'in', [user.partner_id.id]),
+            ('maintenance_request_id.user_id.id', '=', user.id)
+        ]
+        </field>
+    </record>
+</odoo>

--- a/maintenance_timesheet/migrations/15.0.1.1.0/post-migration.py
+++ b/maintenance_timesheet/migrations/15.0.1.1.0/post-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2025 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, "maintenance_timesheet", "15.0.1.1.0/noupdate_changes.xml"
+    )

--- a/maintenance_timesheet/security/maintenance_timesheet_security.xml
+++ b/maintenance_timesheet/security/maintenance_timesheet_security.xml
@@ -6,11 +6,8 @@
         >Users are allowed to access timesheets related to a followed request</field>
         <field name="model_id" ref="model_account_analytic_line" />
         <field name="domain_force">[
-                '|',
-                    ('maintenance_request_id', '=', False),
-                        '|',
-                            ('maintenance_request_id.message_partner_ids', 'in', [user.partner_id.id]),
-                            ('maintenance_request_id.user_id.id', '=', user.id)
+                ('maintenance_request_id.message_partner_ids', 'in', [user.partner_id.id]),
+                ('maintenance_request_id.user_id.id', '=', user.id)
             ]
         </field>
         <field

--- a/maintenance_timesheet/static/description/index.html
+++ b/maintenance_timesheet/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -409,7 +409,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Backport from 16.0: https://github.com/OCA/maintenance/pull/501

Define the correct rule to show only what is related to `maintenance_request_id`

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT56859