### PR TITLE
[IMP] maintenance_project: Show equipments and requests in project update

### DIFF
--- a/maintenance_project/models/project_project.py
+++ b/maintenance_project/models/project_project.py
@@ -56,3 +56,30 @@ class ProjectProject(models.Model):
         action["domain"] = [("project_id", "=", self.id), ("stage_id.done", "=", False)]
         action["context"] = {"default_project_id": self.id}
         return action
+
+    def _get_stat_buttons(self):
+        buttons = super()._get_stat_buttons()
+        if self.env.user.has_group("maintenance.group_equipment_manager"):
+            buttons.append(
+                {
+                    "icon": "cubes",
+                    "text": self.env._("Equipments"),
+                    "number": self.equipment_count,
+                    "action_type": "object",
+                    "action": "action_view_equipment_ids",
+                    "show": self.equipment_count > 0,
+                    "sequence": 5,
+                }
+            )
+            buttons.append(
+                {
+                    "icon": "wrench",
+                    "text": self.env._("Requests"),
+                    "number": self.maintenance_request_count,
+                    "action_type": "object",
+                    "action": "action_view_maintenance_request_ids",
+                    "show": self.maintenance_request_count > 0,
+                    "sequence": 6,
+                }
+            )
+        return buttons

--- a/maintenance_project/tests/test_maintenance_project.py
+++ b/maintenance_project/tests/test_maintenance_project.py
@@ -121,6 +121,33 @@ class TestMaintenanceProject(BaseCommon):
         my_requests = request_obj.search(domain)
         self.assertEqual(len(my_requests), 2)
 
+    def test_project_update_buttons(self):
+        """Test that the project update button is only visible to users with the
+        'Project / Project Manager' group.
+        """
+        user = self._create_new_internal_user(groups="project.group_project_user")
+
+        buttons = self.project1.with_user(user)._get_stat_buttons()
+        self.assertFalse(
+            any(button["action"] == "action_view_equipment_ids" for button in buttons)
+        )
+        self.assertFalse(
+            any(
+                button["action"] == "action_view_maintenance_request_ids"
+                for button in buttons
+            )
+        )
+        buttons = self.project1._get_stat_buttons()
+        self.assertTrue(
+            any(button["action"] == "action_view_equipment_ids" for button in buttons)
+        )
+        self.assertTrue(
+            any(
+                button["action"] == "action_view_maintenance_request_ids"
+                for button in buttons
+            )
+        )
+
     def test_project_action_views(self):
         act1 = self.project1.action_view_equipment_ids()
         self.assertEqual(act1["domain"][0][2], self.project1.id)

--- a/maintenance_project/views/project_project_views.xml
+++ b/maintenance_project/views/project_project_views.xml
@@ -25,7 +25,7 @@
                         <span class="o_value">
                             <t t-esc="record.equipment_count.value" />
                         </span>
-                        <span class="o_label">Equipments</span>
+                        <span class="o_label"> Equipments</span>
                     </div>
                 </a>
                 <a
@@ -38,7 +38,7 @@
                         <span class="o_value">
                             <t t-esc="record.maintenance_request_count.value" />
                         </span>
-                        <span class="o_label">Requests</span>
+                        <span class="o_label"> Requests</span>
                     </div>
                 </a>
             </xpath>
@@ -53,7 +53,7 @@
                     class="oe_stat_button"
                     name="action_view_equipment_ids"
                     type="object"
-                    icon="fa-ticket"
+                    icon="fa-cubes"
                     groups="maintenance.group_equipment_manager"
                 >
                     <field
@@ -66,7 +66,7 @@
                     class="oe_stat_button"
                     name="action_view_maintenance_request_ids"
                     type="object"
-                    icon="fa-tasks"
+                    icon="fa-wrench"
                     groups="maintenance.group_equipment_manager"
                 >
                     <field


### PR DESCRIPTION
- Include the buttons on the update view
- Unify logos format in order to have a better user experience (wrench for requests, cubes for equipments, following Odoo logic)
- Fix a missing space in kanban

<img width="1246" height="188" alt="image" src="https://github.com/user-attachments/assets/6c47c6f9-aaca-4401-9591-96027ed018ad" />

<img width="939" height="177" alt="image" src="https://github.com/user-attachments/assets/e6d4efe5-da06-466f-8949-334cff28df27" />


<img width="506" height="266" alt="image" src="https://github.com/user-attachments/assets/1e05a87e-4c9a-4ac9-8a9e-d3379fbf3745" />

