### PR TITLE
[18.0][FIX] maintenance_product: fix product domain in equipment

### DIFF
--- a/maintenance_product/models/maintenance_equipment.py
+++ b/maintenance_product/models/maintenance_equipment.py
@@ -10,10 +10,12 @@ class MaintenanceEquipment(models.Model):
         comodel_name="product.product",
         string="Product",
         tracking=True,
-        domain=[
-            ("categ_id", "child_of", "product_category_id"),
-            ("maintenance_ok", "=", True),
-        ],
+        domain="""
+            [
+                ('categ_id', 'child_of', product_category_id),
+                ('maintenance_ok', '=', True),
+            ]
+        """,
     )
     product_category_id = fields.Many2one(
         comodel_name="product.category", related="category_id.product_category_id"


### PR DESCRIPTION
error was added in V18 migration: https://github.com/OCA/maintenance/pull/451/commits/a2ee2aae2b34d324c9bd6e8b42823f30573ddd0b

CC @BhaveshHeliconia @etobella @DarkoNikolovski