### PR TITLE
[17.0][IMP] maintenance_location: Add inverse relation and equipment count to locations

### DIFF
--- a/maintenance_location/models/maintenance_location.py
+++ b/maintenance_location/models/maintenance_location.py
@@ -34,6 +34,52 @@ class MaintenanceLocation(models.Model):
     longitude = fields.Float(digits=(16, 5))
     sequence = fields.Integer(default=10)
     active = fields.Boolean(default=True)
+    equipment_ids = fields.One2many(
+        "maintenance.equipment", "location_id", string="Equipments"
+    )
+    child_equipment_ids = fields.Many2many(
+        comodel_name="maintenance.equipment",
+        compute="_compute_child_equipment_ids",
+        string="Child Equipments",
+    )
+    equipment_count = fields.Integer(compute="_compute_equipment_count")
+
+    def _compute_child_equipment_ids(self):
+        all_locations = self.env["maintenance.location"].search(
+            [("id", "child_of", self.ids)]
+        )
+        all_equipments = self.env["maintenance.equipment"].search(
+            [("location_id", "in", all_locations.ids)]
+        )
+        for location in self:
+            descendant_locs = all_locations.filtered(
+                lambda sub_loc, loc=location: sub_loc.parent_path
+                and sub_loc.parent_path.startswith(loc.parent_path)
+                and sub_loc.id != loc.id
+            )
+            location.child_equipment_ids = all_equipments.filtered(
+                lambda eq, d_locs=descendant_locs: eq.location_id in d_locs
+            )
+
+    def _compute_equipment_count(self):
+        all_locations = self.env["maintenance.location"].search(
+            [("id", "child_of", self.ids)]
+        )
+        equip_data = self.env["maintenance.equipment"].read_group(
+            domain=[("location_id", "in", all_locations.ids)],
+            fields=["location_id"],
+            groupby=["location_id"],
+        )
+        count_dict = {x["location_id"][0]: x["location_id_count"] for x in equip_data}
+        for location in self:
+            descendant_ids = all_locations.filtered(
+                lambda sub_loc, loc=location: sub_loc.parent_path
+                and sub_loc.parent_path.startswith(loc.parent_path)
+            ).ids
+
+            location.equipment_count = sum(
+                count_dict.get(d_id, 0) for d_id in descendant_ids
+            )
 
     @api.depends("name", "parent_id.complete_name")
     def _compute_complete_name(self):

--- a/maintenance_location/tests/test_maintenance_location.py
+++ b/maintenance_location/tests/test_maintenance_location.py
@@ -21,11 +21,15 @@ class TestMaintenanceLocation(TransactionCase):
         self.request = self.env["maintenance.request"].create(
             {"name": "Request", "maintenance_team_id": self.team.id}
         )
-
-        self.equipment = self.env["maintenance.equipment"].create(
+        self.env["maintenance.equipment"].create(
             {"name": "Laptop", "location_id": self.location_1.id}
         )
-
+        self.env["maintenance.equipment"].create(
+            {"name": "Printer", "location_id": self.location_1.id}
+        )
+        self.env["maintenance.equipment"].create(
+            {"name": "Scanner", "location_id": self.location_2.id}
+        )
         self.plan = self.env["maintenance.plan"].create(
             {
                 "equipment_id": self.equipment.id,
@@ -37,6 +41,7 @@ class TestMaintenanceLocation(TransactionCase):
                 "location_id": self.location_1.id,
             }
         )
+        self.env.invalidate_all()
 
     def test_maintenance_location(self):
         self.assertEqual(self.location_2.complete_name, "L1 / L2")
@@ -51,3 +56,11 @@ class TestMaintenanceLocation(TransactionCase):
         self.assertTrue(request)
         for r in request:
             self.assertEqual(r.location_id.id, self.location_1.id)
+
+    def test_count_equipment(self):
+        self.assertEqual(self.location_1.equipment_count, 4)
+        self.assertEqual(self.location_2.equipment_count, 1)
+
+    def test_child_equipment_ids(self):
+        self.assertEqual(len(self.location_1.child_equipment_ids), 1)
+        self.assertEqual(len(self.location_2.child_equipment_ids), 0)

--- a/maintenance_location/views/maintenance_location.xml
+++ b/maintenance_location/views/maintenance_location.xml
@@ -15,13 +15,27 @@
                         </h1>
                     </div>
                     <group name="first" col="2">
-                        <field name="description" />
-                        <field name="parent_id" class="oe_inline" />
-                        <label for="latitude" string="Location" />
-                        <span class="oe_inline">
-                            Latitude: <field name="latitude" nolabel="1" /><br />
-                            Longitude: <field name="longitude" nolabel="1" />
-                        </span>
+                        <group>
+                            <field name="description" />
+                            <field name="parent_id" class="oe_inline" />
+                            <label for="latitude" string="Location" />
+                            <span class="oe_inline">
+                                Latitude: <field name="latitude" nolabel="1" /><br />
+                                Longitude: <field name="longitude" nolabel="1" />
+                            </span>
+                        </group>
+                        <group>
+                                <field
+                                name="equipment_ids"
+                                widget="many2many_tags"
+                                string="Equipments"
+                            />
+                                <field
+                                name="child_equipment_ids"
+                                widget="many2many_tags"
+                                string="Child Equipments"
+                            />
+                        </group>
                     </group>
                 </sheet>
             </form>
@@ -42,6 +56,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="complete_name" />
+                <field name="equipment_count" />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Currently, the maintenance_location addon allows assigning a specific location to a maintenance.equipment. However, there is no quick way to check this relationship from the location's perspective.

This introduces the inverse relationship in the maintenance.location model.


maintenance.location model:

Added equipment_ids (One2many) to establish the inverse relation with maintenance.equipment.

Added equipment_count (Computed Integer) to count the number of equipments in a given location.Views:


Views:

Tree view: Added the equipment_count field so users can see the number of devices in each location.

<img width="1918" height="198" alt="tree_view" src="https://github.com/user-attachments/assets/f2aeca05-792d-498c-b8ae-5c30cd77fea3" />


Form view: Added the equipment_ids field (using the many2many_tags widget) to display the specific equipments assigned to the location.

<img width="935" height="454" alt="form_view" src="https://github.com/user-attachments/assets/82dbecd2-3ed7-41fd-87da-bf92ba353aa4" />
