### PR TITLE
[18.0][IMP] maintenance_partner: Added without partner filter

### DIFF
--- a/maintenance_partner/views/maintenance_equipment.xml
+++ b/maintenance_partner/views/maintenance_equipment.xml
@@ -49,6 +49,11 @@
                     string="With Assigned Partner"
                     domain="[('assigned_partner_id', '!=', False)]"
                 />
+                <filter
+                    name="without_assigned_partner"
+                    string="Without Assigned Partner"
+                    domain="[('assigned_partner_id', '=', False)]"
+                />
             </filter>
         </field>
     </record>


### PR DESCRIPTION
Adding extra filter `Without Assigned Partner` allowing the easier search of equipments "Not assigned" + "Without Assigned Partner" and missing spanish translation.
@Tecnativa TT61874
@pedrobaeza @etobella 