### PR TITLE
[19.0][IMP] maintenance_equipment_certification: improve expiration reminder

### DIFF
--- a/maintenance_equipment_certification/models/maintenance_equipment_certificate.py
+++ b/maintenance_equipment_certification/models/maintenance_equipment_certificate.py
@@ -3,6 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from datetime import timedelta
 
+from markupsafe import Markup, escape
+
 from odoo import api, fields, models
 
 
@@ -75,10 +77,29 @@ class MaintenanceEquipmentCertificate(models.Model):
             equipment = cert.equipment_id
             user = equipment.technician_user_id or equipment.owner_user_id
             if not user:
+                equipment.activity_schedule(
+                    "mail.mail_activity_data_todo",
+                    date_deadline=cert.renewal_date,
+                    summary=self.env._("Certificate expiration: no assignee to notify"),
+                    note=Markup(
+                        "Certificate <b>%s</b> (renewal: %s) could not send "
+                        "expiration reminder: no technician or owner is assigned."
+                    )
+                    % (escape(cert.name), cert.renewal_date),
+                )
                 continue
             if template:
                 template.send_mail(
                     cert.id,
                     email_layout_xmlid="mail.mail_notification_light",
+                    email_values={"partner_ids": [user.partner_id.id]},
+                )
+                equipment.message_post(
+                    body=Markup(
+                        "Certificate expiration reminder sent for "
+                        "<b>%s</b> (renewal: %s)."
+                    )
+                    % (escape(cert.name), cert.renewal_date),
+                    subtype_xmlid="mail.mt_note",
                 )
             cert.expiration_notify_count = expected

--- a/maintenance_equipment_certification/tests/test_maintenance_equipment_certification.py
+++ b/maintenance_equipment_certification/tests/test_maintenance_equipment_certification.py
@@ -110,6 +110,10 @@ class TestMaintenanceEquipmentCertification(TransactionCase):
         cert = self._make_certificate(25)
         self._run_cron()
         self.assertEqual(cert.expiration_notify_count, 1)
+        chatter_msgs = self.equipment.message_ids.filtered(
+            lambda m: "Test Certificate" in (m.body or "")
+        )
+        self.assertTrue(chatter_msgs, "Expected chatter note on equipment after send")
 
         # 5 days out: 30-day + 7-day rules now triggered.
         self._shift_renewal(cert, 5)
@@ -183,3 +187,12 @@ class TestMaintenanceEquipmentCertification(TransactionCase):
             cert = self._make_certificate(10, equipment_id=equipment_no_user.id)
             self._run_cron()
             self.assertEqual(cert.expiration_notify_count, 0)
+            self.assertEqual(
+                len(equipment_no_user.activity_ids),
+                1,
+                "Expected one activity on equipment with no assignee",
+            )
+            self.assertIn(
+                "no assignee",
+                equipment_no_user.activity_ids.summary,
+            )


### PR DESCRIPTION
- Fix email recipient: pass partner_ids via email_values so the To field is correctly populated instead of relying on template partner_to
- Log an internal chatter note on the equipment record after each successful reminder send
- Schedule a To-Do activity on the equipment when no technician or owner is assigned, so the gap is visible in the UI


@ForgeFlow