### PR TITLE
[16.0][FIX] base_maintenance: domain team_member_ids

### DIFF
--- a/base_maintenance/models/__init__.py
+++ b/base_maintenance/models/__init__.py
@@ -1,1 +1,2 @@
+from . import maintenance_request
 from . import maintenance_team

--- a/base_maintenance/models/maintenance_request.py
+++ b/base_maintenance/models/maintenance_request.py
@@ -1,0 +1,13 @@
+# Copyright 2026 - TODAY, Cristiano Mafra Junior <cristiano.mafra@escodoo.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class MaintenanceRequest(models.Model):
+    _inherit = "maintenance.request"
+
+    team_member_ids = fields.Many2many(
+        related="maintenance_team_id.member_ids",
+        string="Team Members",
+    )

--- a/base_maintenance/views/maintenance_request_views.xml
+++ b/base_maintenance/views/maintenance_request_views.xml
@@ -13,6 +13,12 @@
                     <!--Empty, to be inherited by other modules.-->
                 </div>
             </xpath>
+            <field name="user_id" position="before">
+                <field name="team_member_ids" invisible="1" />
+            </field>
+            <field name="user_id" position="attributes">
+                <attribute name="domain">[('id', 'in', team_member_ids)]</attribute>
+            </field>
             <field name="description" position="replace">
                 <notebook colspan="2">
                     <page name="description_page" string="Description">


### PR DESCRIPTION
@Escodoo SO571-56

### Summary
- Adds a team_member_ids related field on maintenance.request (derived from maintenance_team_id.member_ids) to expose the selected team's members to the view layer.
- Applies a domain on the Responsible (user_id) field in the maintenance request form so that, when a team is selected, only that team's members are listed as options.
### Motivation
Previously the Responsible dropdown listed all internal users regardless of the selected team, making it easy to accidentally assign a request to someone outside the team. This change improves usability by scoping the selection to the relevant people.

cc @WesleyOliveira98 @marcelsavegnago @kaynnan 