### PR TITLE
[16.0] [IMP] maintenance_project: get all MR filtered by to do

### DIFF
--- a/maintenance_project/models/project_project.py
+++ b/maintenance_project/models/project_project.py
@@ -53,6 +53,6 @@ class ProjectProject(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id(
             "maintenance.hr_equipment_request_action"
         )
-        action["domain"] = [("project_id", "=", self.id), ("stage_id.done", "=", False)]
-        action["context"] = {"default_project_id": self.id}
+        action["domain"] = [("project_id", "=", self.id)]
+        action["context"] = {"default_project_id": self.id, "search_default_todo": 1}
         return action


### PR DESCRIPTION
Before we can search between MRs, only not done are shown. Now we can search between MRs but todo filter is applied by default.

https://github.com/user-attachments/assets/cca84b29-defc-47f9-872b-4dd7ade73e98

